### PR TITLE
Added helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,25 @@
 {
-    "name": "postscripton/laravel-money",
-    "description": "A convenient way to convert numbers from DB or inputs into money strings for humans",
-    "version": "2.2.1",
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "PostScripton",
-            "email": "postscripton.sp@gmail.com"
-        }
-    ],
-    "require": {
-	  	"php": "^7.4"
-    },
-  	"require-dev": {
-        "orchestra/testbench": "^6.15"
+	"name": "postscripton/laravel-money",
+	"description": "A convenient way to convert numbers from DB or inputs into money strings for humans",
+	"version": "2.2.1",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "PostScripton",
+			"email": "postscripton.sp@gmail.com"
+		}
+	],
+	"require": {
+		"php": "^7.4"
+	},
+	"require-dev": {
+		"orchestra/testbench": "^6.15"
 	},
 	"autoload": {
+		"files": [
+			"src/helpers.php"
+		],
 		"psr-4": {
 			"PostScripton\\Money\\": "src/"
 		}
@@ -26,10 +29,10 @@
 			"PostScripton\\Money\\Tests\\": "tests/"
 		}
 	},
-  	"extra": {
-	  	"laravel": {
-		  	"providers": [
-			  	"PostScripton\\Money\\MoneyServiceProvider"
+	"extra": {
+		"laravel": {
+			"providers": [
+				"PostScripton\\Money\\MoneyServiceProvider"
 			]
 		}
 	}

--- a/src/Money.php
+++ b/src/Money.php
@@ -239,7 +239,7 @@ class Money implements MoneyInterface
         $new_amount = $this->getPureNumber() * $coeff;
         $settings = clone $this->settings;
 
-        return new self($new_amount, $currency, $settings->setCurrency($currency));
+        return money($new_amount, $currency, $settings->setCurrency($currency));
     }
 
     public function upload()

--- a/src/Money.php
+++ b/src/Money.php
@@ -11,12 +11,12 @@ class Money implements MoneyInterface
     use MoneyStatic;
     use MoneyHelpers;
 
-    private float $number;
+    private float $amount;
     private ?MoneySettings $settings;
 
-    public function __construct(float $number, $currency = null, $settings = null)
+    public function __construct(float $amount, $currency = null, $settings = null)
     {
-        $this->number = $number;
+        $this->amount = $amount;
         $this->settings = null;
 
         if (is_null($settings) && !($currency instanceof MoneySettings)) {
@@ -68,7 +68,7 @@ class Money implements MoneyInterface
 
     public function getPureNumber(): float
     {
-        return $this->number;
+        return $this->amount;
     }
 
     public function getNumber(): string
@@ -104,37 +104,37 @@ class Money implements MoneyInterface
 
     public function add($money, int $origin = MoneySettings::ORIGIN_INT): self
     {
-        $this->number += $this->numberIntoCorrectOrigin($money, $origin, __METHOD__);
+        $this->amount += $this->numberIntoCorrectOrigin($money, $origin, __METHOD__);
         return $this;
     }
 
     public function subtract($money, int $origin = MoneySettings::ORIGIN_INT): self
     {
-        $this->number -= $this->numberIntoCorrectOrigin($money, $origin, __METHOD__);
+        $this->amount -= $this->numberIntoCorrectOrigin($money, $origin, __METHOD__);
         return $this;
     }
 
     public function multiple(float $number): self
     {
-        $this->number = $this->getPureNumber() * $number;
+        $this->amount = $this->getPureNumber() * $number;
         return $this;
     }
 
     public function divide(float $number): self
     {
-        $this->number = $this->getPureNumber() / $number;
+        $this->amount = $this->getPureNumber() / $number;
         return $this;
     }
 
     public function rebase($money, int $origin = MoneySettings::ORIGIN_INT): self
     {
-        $this->number = $this->numberIntoCorrectOrigin($money, $origin, __METHOD__);
+        $this->amount = $this->numberIntoCorrectOrigin($money, $origin, __METHOD__);
         return $this;
     }
 
     public function clear(): self
     {
-        $this->number = $this->settings()->getOrigin() === MoneySettings::ORIGIN_INT
+        $this->amount = $this->settings()->getOrigin() === MoneySettings::ORIGIN_INT
             ? floor($this->getPureNumber() / $this->getDivisor()) * $this->getDivisor()
             : floor($this->getPureNumber());
 

--- a/src/Traits/MoneyStatic.php
+++ b/src/Traits/MoneyStatic.php
@@ -125,7 +125,7 @@ trait MoneyStatic
 
     public static function make(float $amount, $currency = null, $settings = null): Money
     {
-        return new Money($amount, $currency, $settings);
+        return money($amount, $currency, $settings);
     }
 
     public static function correctInput(string $input): string

--- a/src/Traits/MoneyStatic.php
+++ b/src/Traits/MoneyStatic.php
@@ -123,9 +123,9 @@ trait MoneyStatic
 
     // ========== METHODS ==========
 
-    public static function make(float $number, $currency = null, $settings = null): Money
+    public static function make(float $amount, $currency = null, $settings = null): Money
     {
-        return new Money($number, $currency, $settings);
+        return new Money($amount, $currency, $settings);
     }
 
     public static function correctInput(string $input): string

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,41 @@
+<?php
+
+use PostScripton\Money\Currency;
+use PostScripton\Money\Exceptions\CurrencyDoesNotExistException;
+use PostScripton\Money\Money;
+use PostScripton\Money\MoneySettings;
+
+if (!function_exists('money')) {
+    /**
+     * Creates a Money object
+     * @param float $amount
+     * @param null $currency
+     * @param null $settings
+     * @return Money
+     */
+    function money(float $amount, $currency = null, $settings = null): Money
+    {
+        return new Money($amount, $currency, $settings);
+    }
+}
+
+if (!function_exists('currency')) {
+    /**
+     * Returns currency
+     * @param string $code
+     * @return Currency
+     * @throws CurrencyDoesNotExistException
+     */
+    function currency(string $code): Currency
+    {
+        return Currency::code($code);
+    }
+}
+
+if (!function_exists('settings')) {
+    /** Creates settings for Money object */
+    function settings(): MoneySettings
+    {
+        return new MoneySettings();
+    }
+}

--- a/tests/Feature/HelpersTest.php
+++ b/tests/Feature/HelpersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PostScripton\Money\Tests;
+
+use PostScripton\Money\Currency;
+use PostScripton\Money\Money;
+
+class HelpersTest extends TestCase
+{
+    /** @test */
+    public function create_money_with_money_helper()
+    {
+        $money = money(12345);
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals(12345, $money->getPureNumber());
+    }
+
+    /** @test */
+    public function create_money_with_money_and_currency_helpers()
+    {
+        $money = money(12345, currency('RUB'));
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals('₽', $money->getCurrency()->getSymbol());
+        $this->assertEquals('RUB', $money->getCurrency()->getCode());
+    }
+
+    /** @test */
+    public function create_money_with_money_currency_and_settings_helpers()
+    {
+        $money = money(12345, currency('RUB'), settings()->setHasSpaceBetween(false));
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals('1 234.5₽', $money->toString());
+        $this->assertFalse($money->settings()->hasSpaceBetween());
+    }
+
+    /** @test */
+    public function modify_currency_before_creating_money()
+    {
+        $money = money(12345, currency('usd')->setPosition(Currency::POS_END));
+
+        $this->assertInstanceOf(Money::class, $money);
+        $this->assertEquals('1 234.5 $', $money->toString());
+        $this->assertEquals(Currency::POS_END, $money->getCurrency()->getPosition());
+    }
+}


### PR DESCRIPTION
In this update, helpers were added. Now you can easily create money objects or pass currencies or settings just by calling a proper helper function without importing class names and so on.

- `money()`
- `currency()`
- `settings()`

```php
$money = money(12345);
$money->toString(); // "$ 1 234.5"
```
```php
$money = money(12345, currency("RUB"));
$money->toString(); // "1 234.5 ₽"
```
```php
$money = money(12345, currency("RUB"), settings()->setHasSpaceBetween(false));
$money->toString(); // "1 234.5₽"
```

### Before
```php
use PostScripton\Money\Currency;
use PostScripton\Money\Money;
use PostScripton\Money\MoneySettings;

$settings = (new MoneySettings())->setHasSpaceBetween(false);
$money = new Money(12345, Currency::code("RUB"), $settings);
```