### PR TITLE
Converting Currencies Update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
 		}
 	],
 	"require": {
-		"php": "^7.4"
+		"php": "^7.4",
+		"guzzlehttp/guzzle": "^7.0",
+		"ext-json": "*"
 	},
 	"require-dev": {
 		"orchestra/testbench": "^6.15"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,373 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93fd041459c41e9e3c3c46d5955febec",
-    "packages": [],
+    "content-hash": "b3fb5807e483aa70c4fbca34bb34b721",
+    "packages": [
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "414c24961042f6616fb43e23fa69a785f9fc053e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/414c24961042f6616fb43e23fa69a785f9fc053e",
+                "reference": "414c24961042f6616fb43e23fa69a785f9fc053e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.6.1",
+                "php": "^7.2.5",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.0",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "dev-phpunit8",
+                "phpunit/phpunit": "^8.5.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/master"
+            },
+            "time": "2020-06-27T08:47:54+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
+            },
+            "time": "2021-03-07T09:25:29+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
+                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-zlib": "*",
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
+            },
+            "time": "2021-04-26T09:17:50+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "brick/math",
@@ -566,81 +931,6 @@
                 }
             ],
             "time": "2020-04-13T13:17:36+00:00"
-        },
-        {
-            "name": "guzzlehttp/psr7",
-            "version": "1.8.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/psr7.git",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dc960a912984efb74d0a90222870c72c87f10c91",
-                "reference": "dc960a912984efb74d0a90222870c72c87f10c91",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "ext-zlib": "*",
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
-            },
-            "suggest": {
-                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                },
-                {
-                    "name": "Tobias Schultze",
-                    "homepage": "https://github.com/Tobion"
-                }
-            ],
-            "description": "PSR-7 message implementation that also provides common utility methods",
-            "keywords": [
-                "http",
-                "message",
-                "psr-7",
-                "request",
-                "response",
-                "stream",
-                "uri",
-                "url"
-            ],
-            "support": {
-                "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.2"
-            },
-            "time": "2021-04-26T09:17:50+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -2630,59 +2920,6 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
-            "name": "psr/http-message",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
-            },
-            "time": "2016-08-06T14:39:51+00:00"
-        },
-        {
             "name": "psr/log",
             "version": "1.1.4",
             "source": {
@@ -2782,50 +3019,6 @@
                 "source": "https://github.com/php-fig/simple-cache/tree/master"
             },
             "time": "2017-10-23T01:57:42+00:00"
-        },
-        {
-            "name": "ralouphie/getallheaders",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/getallheaders.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ralph Khattar",
-                    "email": "ralph.khattar@gmail.com"
-                }
-            ],
-            "description": "A polyfill for getallheaders.",
-            "support": {
-                "issues": "https://github.com/ralouphie/getallheaders/issues",
-                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
-            },
-            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "ramsey/collection",

--- a/config/money.php
+++ b/config/money.php
@@ -74,8 +74,8 @@ return [
     |
     | This option controls the default service for converting currencies using API.
 	|
-	| Supported: "currencylayer", "exchangeratesapi"
-	| exchangeratesapi (default)
+	| Supported: "currencylayer", "exchangeratesapi", "openexchangerates"
+	| openexchangerates (default)
     |
     */
 	'service' => 'currencylayer',
@@ -102,6 +102,12 @@ return [
 			'key' => env('EXCHANGERATESAPI_API_KEY'),
 			'secure' => env('EXCHANGERATESAPI_SECURE', false),
 			'base_restriction' => env('EXCHANGERATESAPI_BASE_RESTRICTION', true),
+		],
+		'openexchangerates' => [
+			// https://openexchangerates.org/
+			'class' => \PostScripton\Money\Services\OpenExchangeRatesService::class,
+			'key' => env('OPENEXCHANGERATES_API_KEY'),
+			'base_restriction' => env('OPENEXCHANGERATES_BASE_RESTRICTION', true),
 		],
 	],
 

--- a/config/money.php
+++ b/config/money.php
@@ -75,10 +75,12 @@ return [
     | This option controls the default service for converting currencies using API.
 	|
 	| Supported: "currencylayer", "exchangeratesapi", "openexchangerates"
-	| openexchangerates (default)
+	| and "exchangerate"
+	|
+	| exchangerate (default)
     |
     */
-	'service' => 'currencylayer',
+	'service' => 'exchangerate',
 
 	/*
     |--------------------------------------------------------------------------
@@ -108,6 +110,10 @@ return [
 			'class' => \PostScripton\Money\Services\OpenExchangeRatesService::class,
 			'key' => env('OPENEXCHANGERATES_API_KEY'),
 			'base_restriction' => env('OPENEXCHANGERATES_BASE_RESTRICTION', true),
+		],
+		'exchangerate' => [
+			// https://exchangerate.host/
+			'class' => \PostScripton\Money\Services\ExchangeRateService::class,
 		],
 	],
 

--- a/config/money.php
+++ b/config/money.php
@@ -72,7 +72,9 @@ return [
     | Service
     |--------------------------------------------------------------------------
     |
-    | This option controls the default service for converting currencies using API
+    | This option controls the default service for converting currencies using API.
+	|
+	| Supported: "currencylayer"
     |
     */
 	'service' => 'currencylayer',

--- a/config/money.php
+++ b/config/money.php
@@ -74,7 +74,8 @@ return [
     |
     | This option controls the default service for converting currencies using API.
 	|
-	| Supported: "currencylayer"
+	| Supported: "currencylayer", "exchangeratesapi"
+	| exchangeratesapi (default)
     |
     */
 	'service' => 'currencylayer',
@@ -94,7 +95,14 @@ return [
 			'key' => env('CURRENCYLAYER_API_KEY'),
 			'secure' => false,
 			'source_restriction' => true,
-		]
+		],
+		'exchangeratesapi' => [
+			// https://exchangeratesapi.io/
+			'class' => \PostScripton\Money\Services\ExchangeRatesAPIService::class,
+			'key' => env('EXCHANGERATESAPI_API_KEY'),
+			'secure' => false,
+			'base_restriction' => true,
+		],
 	],
 
 	/*

--- a/config/money.php
+++ b/config/money.php
@@ -17,55 +17,55 @@ return [
     */
 	'default_currency' => 'USD',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Currency Lists
-    |--------------------------------------------------------------------------
-    |
-    | This option controls which list of currencies will be used.
-    |
-    | For now following lists are provided:
-    | 1. all - all the currencies in the world.
-    | 2. popular - only the most popular ones (35) are used. (default)
-    | 3. custom - only custom currencies
-    | 4. ['840', 'EUR', 'RUB'] - array of currency codes you need. Selects from
-    |                            lists both "all" and "custom_currencies" below
-    |
-    | Segregation of currencies is assumed for performance purposes so that
-    | unnecessary ones won't be used.
-    |
-    */
-    'currency_list' => 'popular',
+	/*
+	|--------------------------------------------------------------------------
+	| Currency Lists
+	|--------------------------------------------------------------------------
+	|
+	| This option controls which list of currencies will be used.
+	|
+	| For now following lists are provided:
+	| 1. all - all the currencies in the world.
+	| 2. popular - only the most popular ones (35) are used. (default)
+	| 3. custom - only custom currencies
+	| 4. ['840', 'EUR', 'RUB'] - array of currency codes you need. Selects from
+	|                            lists both "all" and "custom_currencies" below
+	|
+	| Segregation of currencies is assumed for performance purposes so that
+	| unnecessary ones won't be used.
+	|
+	*/
+	'currency_list' => 'popular',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Custom currencies
-    |--------------------------------------------------------------------------
-    |
-    | This option allows you to create you own currencies.
-    |
-    | Each custom currency represents an array with properties:
-    | 1. full_name  - a full qualified name of an currency
-    | 2. name       - a short name of a currency
-    | 3. iso_code   - an alphabetic code
-    | 4. num_code   - a numeric code
-    | 5. symbol     - a symbol of a currency.
-    |               If there are more than one, array of strings is passed.
-    |               "$" or ["$", "$$", "$$$"]
-    | 6. position   - a position of a currency either in the beginning or in the end
-    |               Currency::POS_START or Currency::POS_END
-    |
-    | Example of the existing currency:
-    | [
-    |   'full_name' => 'United States dollar',
-    |   'name' => 'dollar',
-    |   'iso_code' => 'USD',
-    |   'num_code' => '840',
-    |   'symbol' => '$',
-    |   'position' => Currency::POS_START,
-    | ]
-    */
-    'custom_currencies' => [],
+	/*
+	|--------------------------------------------------------------------------
+	| Custom currencies
+	|--------------------------------------------------------------------------
+	|
+	| This option allows you to create you own currencies.
+	|
+	| Each custom currency represents an array with properties:
+	| 1. full_name  - a full qualified name of an currency
+	| 2. name       - a short name of a currency
+	| 3. iso_code   - an alphabetic code
+	| 4. num_code   - a numeric code
+	| 5. symbol     - a symbol of a currency.
+	|               If there are more than one, array of strings is passed.
+	|               "$" or ["$", "$$", "$$$"]
+	| 6. position   - a position of a currency either in the beginning or in the end
+	|               Currency::POS_START or Currency::POS_END
+	|
+	| Example of the existing currency:
+	| [
+	|   'full_name' => 'United States dollar',
+	|   'name' => 'dollar',
+	|   'iso_code' => 'USD',
+	|   'num_code' => '840',
+	|   'symbol' => '$',
+	|   'position' => Currency::POS_START,
+	| ]
+	*/
+	'custom_currencies' => [],
 
 	/*
     |--------------------------------------------------------------------------
@@ -93,15 +93,15 @@ return [
 			// https://currencylayer.com/
 			'class' => \PostScripton\Money\Services\CurrencyLayerService::class,
 			'key' => env('CURRENCYLAYER_API_KEY'),
-			'secure' => false,
-			'source_restriction' => true,
+			'secure' => env('CURRENCYLAYER_SECURE', false),
+			'source_restriction' => env('CURRENCYLAYER_SOURCE_RESTRICTION', true),
 		],
 		'exchangeratesapi' => [
 			// https://exchangeratesapi.io/
 			'class' => \PostScripton\Money\Services\ExchangeRatesAPIService::class,
 			'key' => env('EXCHANGERATESAPI_API_KEY'),
-			'secure' => false,
-			'base_restriction' => true,
+			'secure' => env('EXCHANGERATESAPI_SECURE', false),
+			'base_restriction' => env('EXCHANGERATESAPI_BASE_RESTRICTION', true),
 		],
 	],
 
@@ -125,7 +125,7 @@ return [
 	| like 123(.)4.
     |
     */
-	'decimal_separator'	=> '.',
+	'decimal_separator' => '.',
 
 	/*
     |--------------------------------------------------------------------------
@@ -150,35 +150,35 @@ return [
     */
 	'ends_with_0' => false,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Space between currency and number
-    |--------------------------------------------------------------------------
-    |
-    | This option controls whether there is a space between currency symbol and number
+	/*
+	|--------------------------------------------------------------------------
+	| Space between currency and number
+	|--------------------------------------------------------------------------
+	|
+	| This option controls whether there is a space between currency symbol and number
 	| When true is provided: $( )100
 	| When false is provided: $()100
-    |
-    */
+	|
+	*/
 	'space_between' => true,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Origin number from database
-    |--------------------------------------------------------------------------
-    |
-    | This option controls the default origin for any number that will be passed
-    | for creating a Money object.
-    | It is used, for instance, if all of your money numbers from database are
-    | represented as integer or float.
-    |
-    | For integer you would save money like: 1234, and would like to get "$ 123.4"
-    | For float you would save money line: 123.4, and you would get "$ 123.4"
-    |
-    | Now only two values are provided:
-    | MoneySettings::ORIGIN_INT
-    | MoneySettings::ORIGIN_FLOAT
-    |
-    */
-    'origin' => MoneySettings::ORIGIN_INT
+	/*
+	|--------------------------------------------------------------------------
+	| Origin number from database
+	|--------------------------------------------------------------------------
+	|
+	| This option controls the default origin for any number that will be passed
+	| for creating a Money object.
+	| It is used, for instance, if all of your money numbers from database are
+	| represented as integer or float.
+	|
+	| For integer you would save money like: 1234, and would like to get "$ 123.4"
+	| For float you would save money line: 123.4, and you would get "$ 123.4"
+	|
+	| Now only two values are provided:
+	| MoneySettings::ORIGIN_INT
+	| MoneySettings::ORIGIN_FLOAT
+	|
+	*/
+	'origin' => MoneySettings::ORIGIN_INT
 ];

--- a/config/money.php
+++ b/config/money.php
@@ -69,6 +69,34 @@ return [
 
 	/*
     |--------------------------------------------------------------------------
+    | Service
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default service for converting currencies using API
+    |
+    */
+	'service' => 'currencylayer',
+
+	/*
+    |--------------------------------------------------------------------------
+    | Services
+    |--------------------------------------------------------------------------
+    |
+    | This option contains all the API services for converting currencies
+    |
+    */
+	'services' => [
+		'currencylayer' => [
+			// https://currencylayer.com/
+			'class' => \PostScripton\Money\Services\CurrencyLayerService::class,
+			'key' => env('CURRENCYLAYER_API_KEY'),
+			'secure' => false,
+			'source_restriction' => true,
+		]
+	],
+
+	/*
+    |--------------------------------------------------------------------------
     | Thousands separator
     |--------------------------------------------------------------------------
     |

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="Unit">
-      <directory suffix="Test.php">./tests/Unit</directory>
-    </testsuite>
-    <testsuite name="Feature">
-      <directory suffix="Test.php">./tests/Feature</directory>
-    </testsuite>
-  </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -226,7 +226,7 @@ class Currency
 
 		$this->full_name = $currency['full_name'];
 		$this->name = $currency['name'];
-		$this->iso_code = $currency['iso_code'];
+		$this->iso_code = strtoupper($currency['iso_code']);
 		$this->num_code = $currency['num_code'];
 		$this->symbol = $currency['symbol'];
 		$this->position = $currency['position'] ?? self::POS_END;

--- a/src/Exceptions/ServiceClassDoesNotExistException.php
+++ b/src/Exceptions/ServiceClassDoesNotExistException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PostScripton\Money\Exceptions;
+
+class ServiceClassDoesNotExistException extends BaseException
+{
+	public function __construct(string $value, $code = 0, BaseException $previous = null)
+	{
+		parent::__construct(
+			"The service class \"{$value}\" doesn't exist.",
+			$code,
+			$previous
+		);
+	}
+}

--- a/src/Exceptions/ServiceDoesNotExistException.php
+++ b/src/Exceptions/ServiceDoesNotExistException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PostScripton\Money\Exceptions;
+
+class ServiceDoesNotExistException extends BaseException
+{
+	public function __construct(string $service, $code = 0, BaseException $previous = null)
+	{
+		parent::__construct(
+			"The service \"{$service}\" doesn't exist in the \"services\" property.",
+			$code,
+			$previous
+		);
+	}
+}

--- a/src/Exceptions/ServiceDoesNotHaveClassException.php
+++ b/src/Exceptions/ServiceDoesNotHaveClassException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PostScripton\Money\Exceptions;
+
+class ServiceDoesNotHaveClassException extends BaseException
+{
+	public function __construct(string $value, $code = 0, BaseException $previous = null)
+	{
+		parent::__construct(
+			"The service \"{$value}\" doesn't have the \"class\" property.",
+			$code,
+			$previous
+		);
+	}
+}

--- a/src/Exceptions/ServiceDoesNotInheritServiceException.php
+++ b/src/Exceptions/ServiceDoesNotInheritServiceException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PostScripton\Money\Exceptions;
+
+use PostScripton\Money\Services\AbstractService;
+
+class ServiceDoesNotInheritServiceException extends BaseException
+{
+	public function __construct(string $value, $code = 0, BaseException $previous = null)
+	{
+		parent::__construct(
+			"The given service class \"{$value}\" doesn't inherit the \"" . AbstractService::class . "\".",
+			$code,
+			$previous
+		);
+	}
+}

--- a/src/Exceptions/ServiceDoesNotSupportCurrencyException.php
+++ b/src/Exceptions/ServiceDoesNotSupportCurrencyException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PostScripton\Money\Exceptions;
+
+class ServiceDoesNotSupportCurrencyException extends BaseException
+{
+	public function __construct(string $class, $code = 0, BaseException $previous = null)
+	{
+		parent::__construct(
+			"The service class \"{$class}\" doesn't exist.",
+			$code,
+			$previous
+		);
+	}
+}

--- a/src/Exceptions/ServiceRequestFailedException.php
+++ b/src/Exceptions/ServiceRequestFailedException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PostScripton\Money\Exceptions;
+
+class ServiceRequestFailedException extends BaseException
+{
+	public function __construct(string $service, string $err_code, string $err_msg, $code = 0, BaseException $previous = null)
+	{
+		parent::__construct(
+			"{$service}: [{$err_code}] {$err_msg}",
+			$code,
+			$previous
+		);
+	}
+}

--- a/src/Money.php
+++ b/src/Money.php
@@ -29,7 +29,7 @@ class Money implements MoneyInterface
             return;
         }
 
-        // Only one passed. It may be Currency or Settings
+        // Is $currency a Currency or Settings?
         if ($currency instanceof Currency) {
             $settings->setCurrency($currency);
         } elseif ($currency instanceof MoneySettings) {

--- a/src/Money.php
+++ b/src/Money.php
@@ -70,16 +70,16 @@ class Money implements MoneyInterface
         return $this->settings;
     }
 
-    public function getPureNumber(): float
+    public function getPureAmount(): float
     {
         return $this->amount;
     }
 
-    public function getNumber(): string
+    public function getAmount(): string
     {
         $amount = $this->settings()->getOrigin() === MoneySettings::ORIGIN_INT
-            ? (float)($this->getPureNumber() / $this->getDivisor())
-            : $this->getPureNumber();
+            ? (float)($this->getPureAmount() / $this->getDivisor())
+            : $this->getPureAmount();
 
         $money = number_format(
             $amount,
@@ -120,13 +120,13 @@ class Money implements MoneyInterface
 
     public function multiple(float $number): self
     {
-        $this->amount = $this->getPureNumber() * $number;
+        $this->amount = $this->getPureAmount() * $number;
         return $this;
     }
 
     public function divide(float $number): self
     {
-        $this->amount = $this->getPureNumber() / $number;
+        $this->amount = $this->getPureAmount() / $number;
         return $this;
     }
 
@@ -139,8 +139,8 @@ class Money implements MoneyInterface
     public function clear(): self
     {
         $this->amount = $this->settings()->getOrigin() === MoneySettings::ORIGIN_INT
-            ? floor($this->getPureNumber() / $this->getDivisor()) * $this->getDivisor()
-            : floor($this->getPureNumber());
+            ? floor($this->getPureAmount() / $this->getDivisor()) * $this->getDivisor()
+            : floor($this->getPureAmount());
 
         return $this;
     }
@@ -152,17 +152,17 @@ class Money implements MoneyInterface
 
     public function isNegative(): bool
     {
-        return $this->getPureNumber() < 0;
+        return $this->getPureAmount() < 0;
     }
 
     public function isPositive(): bool
     {
-        return $this->getPureNumber() > 0;
+        return $this->getPureAmount() > 0;
     }
 
     public function isEmpty(): bool
     {
-        return empty($this->getPureNumber());
+        return empty($this->getPureAmount());
     }
 
     public function lessThan($money, int $origin = MoneySettings::ORIGIN_INT): bool
@@ -176,10 +176,10 @@ class Money implements MoneyInterface
         }
 
         if ($money instanceof self) {
-            $money = $money->getPureNumber();
+            $money = $money->getPureAmount();
         }
 
-        return $this->getPureNumber() < $money;
+        return $this->getPureAmount() < $money;
     }
 
     public function lessThanOrEqual($money, int $origin = MoneySettings::ORIGIN_INT): bool
@@ -193,10 +193,10 @@ class Money implements MoneyInterface
         }
 
         if ($money instanceof self) {
-            $money = $money->getPureNumber();
+            $money = $money->getPureAmount();
         }
 
-        return $this->getPureNumber() <= $money;
+        return $this->getPureAmount() <= $money;
     }
 
     public function greaterThan($money, int $origin = MoneySettings::ORIGIN_INT): bool
@@ -210,10 +210,10 @@ class Money implements MoneyInterface
         }
 
         if ($money instanceof self) {
-            $money = $money->getPureNumber();
+            $money = $money->getPureAmount();
         }
 
-        return $this->getPureNumber() > $money;
+        return $this->getPureAmount() > $money;
     }
 
     public function greaterThanOrEqual($money, int $origin = MoneySettings::ORIGIN_INT): bool
@@ -227,10 +227,10 @@ class Money implements MoneyInterface
         }
 
         if ($money instanceof self) {
-            $money = $money->getPureNumber();
+            $money = $money->getPureAmount();
         }
 
-        return $this->getPureNumber() >= $money;
+        return $this->getPureAmount() >= $money;
     }
 
     public function equals(self $money, bool $strict = true): bool
@@ -249,7 +249,7 @@ class Money implements MoneyInterface
 			$rate = $this->service()->rate($this->getCurrency()->getCode(), $currency->getCode(), $date);
 		}
 
-		$new_amount = $this->getPureNumber() * $rate;
+		$new_amount = $this->getPureAmount() * $rate;
 		$settings = clone $this->settings;
 
 		return money($new_amount, $currency, $settings);
@@ -262,7 +262,7 @@ class Money implements MoneyInterface
 		}
 
 		$money_amount = $this->numberIntoCorrectOrigin($money, $money->settings()->getOrigin(), __METHOD__);
-		$amount = $this->getPureNumber() - $money_amount;
+		$amount = $this->getPureAmount() - $money_amount;
 		$settings = is_null($settings) ? clone $this->settings() : $settings;
 
 		return money($amount, $this->getCurrency(), $settings)->toString();
@@ -271,8 +271,8 @@ class Money implements MoneyInterface
     public function upload()
     {
         return $this->settings()->getOrigin() === MoneySettings::ORIGIN_INT
-            ? (int)floor($this->getPureNumber())
-            : (float)floor($this->getPureNumber() * $this->getDivisor()) / $this->getDivisor();
+            ? (int)floor($this->getPureAmount())
+            : (float)floor($this->getPureAmount() * $this->getDivisor()) / $this->getDivisor();
     }
 
     public function toString(): string

--- a/src/Money.php
+++ b/src/Money.php
@@ -2,6 +2,7 @@
 
 namespace PostScripton\Money;
 
+use Illuminate\Support\Carbon;
 use PostScripton\Money\Exceptions\NotNumericOrMoneyException;
 use PostScripton\Money\Exceptions\ServiceDoesNotSupportCurrencyException;
 use PostScripton\Money\Services\ServiceInterface;
@@ -236,7 +237,7 @@ class Money implements MoneyInterface
         return $strict ? $this === $money : $this == $money;
     }
 
-    public function convertInto(Currency $currency, ?float $rate = null): self
+    public function convertInto(Currency $currency, ?float $rate = null, ?Carbon $date = null): self
 	{
 		// Convert online
 		if (is_null($rate)) {
@@ -244,7 +245,7 @@ class Money implements MoneyInterface
 				throw new ServiceDoesNotSupportCurrencyException($this->service()->getClassName());
 			}
 
-			$rate = $this->service()->rate($this->getCurrency()->getCode(), $currency->getCode());
+			$rate = $this->service()->rate($this->getCurrency()->getCode(), $currency->getCode(), $date);
 		}
 
 		$new_amount = $this->getPureNumber() * $rate;

--- a/src/Money.php
+++ b/src/Money.php
@@ -3,6 +3,7 @@
 namespace PostScripton\Money;
 
 use Illuminate\Support\Carbon;
+use PostScripton\Money\Exceptions\MoneyHasDifferentCurrenciesException;
 use PostScripton\Money\Exceptions\NotNumericOrMoneyException;
 use PostScripton\Money\Exceptions\ServiceDoesNotSupportCurrencyException;
 use PostScripton\Money\Services\ServiceInterface;
@@ -252,6 +253,19 @@ class Money implements MoneyInterface
 		$settings = clone $this->settings;
 
 		return money($new_amount, $currency, $settings);
+	}
+
+	public function difference(self $money, ?MoneySettings $settings = null): string
+	{
+		if (!$this->isSameCurrency($money)) {
+			throw new MoneyHasDifferentCurrenciesException(__METHOD__, 1, '$money');
+		}
+
+		$money_amount = $this->numberIntoCorrectOrigin($money, $money->settings()->getOrigin(), __METHOD__);
+		$amount = $this->getPureNumber() - $money_amount;
+		$settings = is_null($settings) ? clone $this->settings() : $settings;
+
+		return money($amount, $this->getCurrency(), $settings)->toString();
 	}
 
     public function upload()

--- a/src/MoneyInterface.php
+++ b/src/MoneyInterface.php
@@ -2,8 +2,10 @@
 
 namespace PostScripton\Money;
 
+use Illuminate\Support\Carbon;
 use PostScripton\Money\Exceptions\MoneyHasDifferentCurrenciesException;
 use PostScripton\Money\Exceptions\NotNumericOrMoneyException;
+use PostScripton\Money\Services\ServiceInterface;
 
 interface MoneyInterface
 {
@@ -247,17 +249,48 @@ interface MoneyInterface
      */
     public function greaterThanOrEqual($money, int $origin = MoneySettings::ORIGIN_INT): bool;
 
-    /**
-     * Converts money into another currency using coefficient between currencies
-     * <p>USD -> RUB = 75.79 / 1</p>
-     * <p>RUB -> USD = 1 / 75.79</p>
-     * @param Currency $currency <p>
-     * Currency you want to convert into </p>
-     * @param float $coeff <p>
-     * Coefficient between the money's currency and the chosen one
-     * @return Money
-     */
-    public function convertOfflineInto(Currency $currency, float $coeff): Money;
+	/**
+	 * Checks whether two money objects are equal or not
+	 * @param Money $money
+	 * @param bool $strict <p>
+	 * Whether it is === or ==
+	 * @return bool
+	 */
+	public function equals(Money $money, bool $strict = true): bool;
+
+	/**
+	 * Converts money into another currency using an exchange rate between currencies
+	 * <p>USD -> RUB = 75.79 / 1</p>
+	 * <p>RUB -> USD = 1 / 75.79</p> <br/> <p>
+	 * You can do it whether online or offline by not passing or passing the $rate parameter
+	 * </p>
+	 * @param Currency $currency <p>
+	 * Currency you want to convert into </p>
+	 * @param float|null $rate <p>
+	 * Rate of the money's currency and the chosen one </p>
+	 * @param Carbon|null $date <p>
+	 * Historical mode. Pass the date you want to get rate of.
+	 * </p>
+	 * @return Money
+	 */
+    public function convertInto(Currency $currency, ?float $rate = null, ?Carbon $date = null): Money;
+
+	/**
+	 * Shows the difference between two money objects <p>
+	 * $50 - $100 = "$ -50" </p>
+	 * @param Money $money <p>
+	 * The given money must be the same currency as the first one </p>
+	 * @param MoneySettings|null $settings <p>
+	 * Settings for displaying the difference </p>
+	 * @return string
+	 */
+	public function difference(Money $money, ?MoneySettings $settings = null): string;
+
+	/**
+	 * Allows you to get access to the selected service from the config file
+	 * @return ServiceInterface
+	 */
+	public function service(): ServiceInterface;
 
     /**
      * Converts the money into the number according to origin for storing in database <p>

--- a/src/MoneyInterface.php
+++ b/src/MoneyInterface.php
@@ -94,14 +94,14 @@ interface MoneyInterface
      * For example, "$ 1 234.5" -> "1 234.5" </p>
      * @return string
      */
-    public function getNumber(): string;
+    public function getAmount(): string;
 
     /**
      * Returns a pure number that uses for calculations. Not usually used <p>
      * For example, you see "13.3" but within it looks like 13.276686139139672 </p>
      * @return float
      */
-    public function getPureNumber(): float;
+    public function getPureAmount(): float;
 
     /**
      * Shortcut for returning the currency <p>

--- a/src/MoneyServiceProvider.php
+++ b/src/MoneyServiceProvider.php
@@ -49,7 +49,7 @@ class MoneyServiceProvider extends ServiceProvider
 
 	protected function registerService()
 	{
-		$this->app->singleton(ServiceInterface::class, function ($app) {
+		$this->app->bind(ServiceInterface::class, function ($app) {
 			$config = config('money.services.' . config('money.service'));
 
 			if (is_null($config)) {

--- a/src/MoneyServiceProvider.php
+++ b/src/MoneyServiceProvider.php
@@ -49,7 +49,7 @@ class MoneyServiceProvider extends ServiceProvider
 
 	protected function registerService()
 	{
-		$this->app->bind(ServiceInterface::class, function ($app) {
+		$this->app->singleton(ServiceInterface::class, function ($app) {
 			$config = config('money.services.' . config('money.service'));
 
 			if (is_null($config)) {

--- a/src/MoneyServiceProvider.php
+++ b/src/MoneyServiceProvider.php
@@ -3,14 +3,17 @@
 namespace PostScripton\Money;
 
 use Illuminate\Support\ServiceProvider;
+use PostScripton\Money\Exceptions\ServiceClassDoesNotExistException;
+use PostScripton\Money\Exceptions\ServiceDoesNotHaveClassException;
+use PostScripton\Money\Exceptions\ServiceDoesNotInheritServiceException;
 use PostScripton\Money\Exceptions\UndefinedOriginException;
+use PostScripton\Money\Services\ServiceInterface;
 
 class MoneyServiceProvider extends ServiceProvider
 {
-    public function register()
-    {
-        $this->mergeConfigFrom($this->getConfigPath(), 'money');
-    }
+	public function boot()
+	{
+		$this->mergeConfigFrom($this->getConfigPath(), 'money');
 
     public function boot()
     {
@@ -27,21 +30,21 @@ class MoneyServiceProvider extends ServiceProvider
 				->setHasSpaceBetween(config('money.space_between', true))
 				->setOrigin(config('money.origin', MoneySettings::ORIGIN_INT));
 		} catch (UndefinedOriginException $e) {
-        	dd($e->getMessage());
+			dd($e->getMessage());
 		}
 
 		Money::set($settings);
-    }
+	}
 
-    protected function registerPublishing()
-    {
-        $this->publishes(
-            [
-                $this->getConfigPath() => config_path('money.php'),
-            ],
-            'money'
-        );
-    }
+	protected function registerPublishing()
+	{
+		$this->publishes(
+			[
+				$this->getConfigPath() => config_path('money.php'),
+			],
+			'money'
+		);
+	}
 
     private function getConfigPath(): string
     {

--- a/src/MoneySettings.php
+++ b/src/MoneySettings.php
@@ -130,8 +130,8 @@ class MoneySettings implements MoneySettingsInterface
         if (!is_null($this->money)) {
             if ($old_origin !== $origin) {
                 $number = $old_origin === MoneySettings::ORIGIN_INT
-                    ? $this->money->getPureNumber() / $this->getDivisor()
-                    : $this->money->getPureNumber() * $this->getDivisor();
+                    ? $this->money->getPureAmount() / $this->getDivisor()
+                    : $this->money->getPureAmount() * $this->getDivisor();
 
                 $this->money->rebase($number, $origin);
             }

--- a/src/Services/AbstractService.php
+++ b/src/Services/AbstractService.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace PostScripton\Money\Services;
+
+use GuzzleHttp\Client;
+
+abstract class AbstractService implements ServiceInterface
+{
+	protected array $config;
+	protected Client $client;
+
+	protected const USER_AGENT = 'PostScripton/laravel-money';
+
+	protected const FROM_TO_FORMAT = 1;
+	protected const TO_FORMAT = 2;
+
+	protected string $currencies = 'symbols';
+	protected string $base = 'base';
+	protected string $result = 'rates';
+
+	public function __construct(array $config)
+	{
+		$this->config = $config;
+		$this->boot();
+	}
+
+	public function getClassName(): string
+	{
+		return static::class;
+	}
+
+	public function boot(): void
+	{
+		$this->registerClient();
+	}
+
+	protected function registerClient(): void
+	{
+		$base = [
+			'base_uri' => $this->url(),
+			'headers' => [
+				'User-Agent' => self::USER_AGENT,
+			],
+			'query' => $this->baseQuery(),
+			'http_errors' => false,
+		];
+
+		$this->client = new Client($base);
+	}
+
+	protected function baseQuery(): array
+	{
+		return [
+			'access_key' => $this->config['key'],
+		];
+	}
+
+	public function url(): string
+	{
+		return $this->protocol() . '://' . trim($this->domain(), '/') . '/' . trim($this->uri(), '/');
+	}
+
+	protected function protocol(): string
+	{
+		if (!array_key_exists('secure', $this->config)) {
+			return 'https';
+		}
+
+		return $this->config['secure'] ? 'https' : 'http';
+	}
+
+	protected function uri(): string
+	{
+		return '';
+	}
+
+	public function rate(string $from, string $to): float
+	{
+		$options = [$this->currencies => implode(',', [$from, $to])];
+
+		if ($this->doesNotHaveBaseRestriction()) {
+			$options = array_merge($options, [$this->base => $from]);
+		}
+
+		$response = $this->client->get($this->latestUri(), $this->query($options));
+		$data = json_decode($response->getBody()->getContents(), true);
+
+		$this->validateResponse($data);
+
+		return $data[$this->result][$this->result($from, $to)] /
+			$data[$this->result][$this->result($from, $from)];
+	}
+
+	public function supports(string $iso): bool
+	{
+		$response = $this->client->get($this->supportedUri());
+		$data = json_decode($response->getBody()->getContents(), true);
+
+		$this->validateResponse($data);
+
+		return in_array($iso, array_keys($data[$this->currencies]));
+	}
+
+	protected static function BASE_CURRENCY(): string
+	{
+		return 'USD';
+	}
+
+	protected function resultFormat(): int
+	{
+		return self::TO_FORMAT;
+	}
+
+	private function hasBaseRestriction(): bool
+	{
+		if (!array_key_exists('base_restriction', $this->config)) {
+			return false;
+		}
+
+		return $this->config['base_restriction'];
+	}
+
+	private function doesNotHaveBaseRestriction(): bool
+	{
+		return !$this->hasBaseRestriction();
+	}
+
+	private function result(string $from, string $to): string
+	{
+		if ($this->resultFormat() === self::TO_FORMAT) {
+			return $to;
+		}
+
+		return $this->hasBaseRestriction()
+			? static::BASE_CURRENCY() . $to
+			: $from . $to;
+	}
+
+	private function query(array $options): array
+	{
+		return [
+			'query' => array_merge($this->client->getConfig('query'), $options)
+		];
+	}
+
+	abstract protected function domain(): string;
+
+	abstract protected function supportedUri(): string;
+
+	abstract protected function latestUri(): string;
+
+	abstract protected function validateResponse(array $data): void;
+}

--- a/src/Services/AbstractService.php
+++ b/src/Services/AbstractService.php
@@ -118,6 +118,16 @@ abstract class AbstractService implements ServiceInterface
 		return self::TO_FORMAT;
 	}
 
+	protected function supportedData(array $data, string $index): array
+	{
+		return $data[$index];
+	}
+
+	protected function latestData(array $data, string $index): float
+	{
+		return $data[$this->result][$index];
+	}
+
 	private function hasBaseRestriction(): bool
 	{
 		if (!array_key_exists('base_restriction', $this->config)) {
@@ -157,6 +167,7 @@ abstract class AbstractService implements ServiceInterface
 	abstract protected function latestUri(): string;
 
 	abstract protected function historicalUri(Carbon $date, array &$query): string;
+
 
 	abstract protected function validateResponse(array $data): void;
 }

--- a/src/Services/CurrencyLayerService.php
+++ b/src/Services/CurrencyLayerService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PostScripton\Money\Services;
+
+use PostScripton\Money\Exceptions\ServiceRequestFailedException;
+
+class CurrencyLayerService extends AbstractService
+{
+	protected string $currencies = 'currencies';
+	protected string $base = 'source';
+	protected string $result = 'quotes';
+
+	protected function domain(): string
+	{
+		return 'api.currencylayer.com';
+	}
+
+	protected function supportedUri(): string
+	{
+		return 'list';
+	}
+
+	protected function latestUri(): string
+	{
+		return 'live';
+	}
+
+	protected static function BASE_CURRENCY(): string
+	{
+		return 'USD';
+	}
+
+	protected function validateResponse(array $data): void
+	{
+		// Verify the server response
+		if (!$data['success']) {
+			throw new ServiceRequestFailedException($this->getClassName(), $data['error']['code'], $data['error']['info']);
+		}
+	}
+}

--- a/src/Services/CurrencyLayerService.php
+++ b/src/Services/CurrencyLayerService.php
@@ -2,6 +2,7 @@
 
 namespace PostScripton\Money\Services;
 
+use Illuminate\Support\Carbon;
 use PostScripton\Money\Exceptions\ServiceRequestFailedException;
 
 class CurrencyLayerService extends AbstractService
@@ -23,6 +24,15 @@ class CurrencyLayerService extends AbstractService
 	protected function latestUri(): string
 	{
 		return 'live';
+	}
+
+	protected function historicalUri(Carbon $date, array &$query): string
+	{
+		$query = array_merge($query, [
+			'date' => $date->format(self::DATE_FORMAT)
+		]);
+
+		return 'historical';
 	}
 
 	protected static function BASE_CURRENCY(): string

--- a/src/Services/ExchangeRateService.php
+++ b/src/Services/ExchangeRateService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PostScripton\Money\Services;
+
+use Illuminate\Support\Carbon;
+use PostScripton\Money\Exceptions\ServiceRequestFailedException;
+
+class ExchangeRateService extends AbstractService
+{
+	protected function domain(): string
+	{
+		return 'api.exchangerate.host';
+	}
+
+	protected function supportedUri(): string
+	{
+		return 'symbols';
+	}
+
+	protected function latestUri(): string
+	{
+		return 'latest';
+	}
+
+	protected function historicalUri(Carbon $date, array &$query): string
+	{
+		return $date->format(self::DATE_FORMAT);
+	}
+
+	protected function baseQuery(): array
+	{
+		return [];
+	}
+
+	protected function validateResponse(array $data): void
+	{
+		// Verify the server response
+		if (array_key_exists('error', $data)) {
+			throw new ServiceRequestFailedException($this->getClassName(), $data['error']['code'], $data['error']['info']);
+		}
+	}
+}

--- a/src/Services/ExchangeRatesAPIService.php
+++ b/src/Services/ExchangeRatesAPIService.php
@@ -2,6 +2,7 @@
 
 namespace PostScripton\Money\Services;
 
+use Illuminate\Support\Carbon;
 use PostScripton\Money\Exceptions\ServiceRequestFailedException;
 
 class ExchangeRatesAPIService extends AbstractService
@@ -24,6 +25,11 @@ class ExchangeRatesAPIService extends AbstractService
 	protected function latestUri(): string
 	{
 		return 'latest';
+	}
+
+	protected function historicalUri(Carbon $date, array &$query): string
+	{
+		return $date->format(self::DATE_FORMAT);
 	}
 
 	protected function validateResponse(array $data): void

--- a/src/Services/ExchangeRatesAPIService.php
+++ b/src/Services/ExchangeRatesAPIService.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PostScripton\Money\Services;
+
+use PostScripton\Money\Exceptions\ServiceRequestFailedException;
+
+class ExchangeRatesAPIService extends AbstractService
+{
+	protected function domain(): string
+	{
+		return 'api.exchangeratesapi.io';
+	}
+
+	protected function uri(): string
+	{
+		return 'v1';
+	}
+
+	protected function supportedUri(): string
+	{
+		return 'symbols';
+	}
+
+	protected function latestUri(): string
+	{
+		return 'latest';
+	}
+
+	protected function validateResponse(array $data): void
+	{
+		// Verify the server response
+		if (array_key_exists('error', $data)) {
+			throw new ServiceRequestFailedException($this->getClassName(), $data['error']['code'], $data['error']['info']);
+		}
+	}
+}

--- a/src/Services/OpenExchangeRatesService.php
+++ b/src/Services/OpenExchangeRatesService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PostScripton\Money\Services;
+
+use Illuminate\Support\Carbon;
+use PostScripton\Money\Exceptions\ServiceRequestFailedException;
+
+class OpenExchangeRatesService extends AbstractService
+{
+	protected function domain(): string
+	{
+		return 'openexchangerates.org';
+	}
+
+	protected function uri(): string
+	{
+		return 'api';
+	}
+
+	protected function latestUri(): string
+	{
+		return 'latest.json';
+	}
+
+	protected function supportedUri(): string
+	{
+		return 'currencies.json';
+	}
+
+	protected function historicalUri(Carbon $date, array &$query): string
+	{
+		return 'historical/' . $date->format(self::DATE_FORMAT) . '.json';
+	}
+
+	protected function baseQuery(): array
+	{
+		return ['app_id' => $this->config['key']];
+	}
+
+	protected function supportedData(array $data, string $index): array
+	{
+		return $data;
+	}
+
+	protected function validateResponse(array $data): void
+	{
+		// Verify the server response
+		if (array_key_exists('error', $data)) {
+			throw new ServiceRequestFailedException($this->getClassName(), $data['status'], $data['description']);
+		}
+	}
+}

--- a/src/Services/ServiceInterface.php
+++ b/src/Services/ServiceInterface.php
@@ -2,6 +2,8 @@
 
 namespace PostScripton\Money\Services;
 
+use Illuminate\Support\Carbon;
+
 interface ServiceInterface
 {
 	/**
@@ -13,9 +15,10 @@ interface ServiceInterface
 	 * Currency exchange rate
 	 * @param string $from
 	 * @param string $to
+	 * @param Carbon|null $date
 	 * @return float
 	 */
-	public function rate(string $from, string $to): float;
+	public function rate(string $from, string $to, ?Carbon $date = null): float;
 
 	/**
 	 * Whether the service supports currencies or not

--- a/src/Services/ServiceInterface.php
+++ b/src/Services/ServiceInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PostScripton\Money\Services;
+
+interface ServiceInterface
+{
+	/**
+	 * Runs at the booting of the service
+	 */
+	public function boot(): void;
+
+	/**
+	 * Currency exchange rate
+	 * @param string $from
+	 * @param string $to
+	 * @return float
+	 */
+	public function rate(string $from, string $to): float;
+
+	/**
+	 * Whether the service supports currencies or not
+	 * @param string $iso
+	 * @return bool
+	 */
+	public function supports(string $iso): bool;
+
+	/**
+	 * Gives a full service class name with namespace
+	 * @return string
+	 */
+	public function getClassName(): string;
+
+	/**
+	 * A base url for API requests
+	 * @return string
+	 */
+	public function url(): string;
+}

--- a/src/Traits/MoneyHelpers.php
+++ b/src/Traits/MoneyHelpers.php
@@ -42,7 +42,7 @@ trait MoneyHelpers
             }
 
             $origin = $money->settings()->getOrigin();
-            $money = $money->getPureNumber();
+            $money = $money->getPureAmount();
         }
 
         if (MoneySettings::isIncorrectOrigin($origin)) {

--- a/src/Traits/MoneyStatic.php
+++ b/src/Traits/MoneyStatic.php
@@ -148,7 +148,7 @@ trait MoneyStatic
         $min = $monies[0];
 
         for ($i = 1; $i < count($monies); $i++) {
-            if (($money = $monies[$i])->getPureNumber() < $min->getPureNumber()) {
+            if (($money = $monies[$i])->getPureAmount() < $min->getPureAmount()) {
                 $min = $money;
             }
         }
@@ -167,7 +167,7 @@ trait MoneyStatic
         $max = $monies[0];
 
         for ($i = 1; $i < count($monies); $i++) {
-            if (($money = $monies[$i])->getPureNumber() > $max->getPureNumber()) {
+            if (($money = $monies[$i])->getPureAmount() > $max->getPureAmount()) {
                 $max = $money;
             }
         }
@@ -184,7 +184,7 @@ trait MoneyStatic
         self::currenciesAreNotSame($monies, Money::class . '::' . __FUNCTION__, 1, '$monies');
 
         $sum = array_reduce($monies, function (float $acc, Money $money) {
-            return $acc + $money->getPureNumber();
+            return $acc + $money->getPureAmount();
         }, 0);
 
         return new Money($sum / count($monies),
@@ -201,7 +201,7 @@ trait MoneyStatic
         self::currenciesAreNotSame($monies, Money::class . '::' . __FUNCTION__, 1, '$monies');
 
         $sum = array_reduce($monies, function (float $acc, Money $money) {
-            return $acc + $money->getPureNumber();
+            return $acc + $money->getPureAmount();
         }, 0);
 
         return new Money($sum,
@@ -230,7 +230,7 @@ trait MoneyStatic
         }
 
         return $currency->getPosition() === Currency::POS_START
-            ? $currency->getSymbol() . $space . $money->getNumber()
-            : $money->getNumber() . $space . $currency->getSymbol();
+            ? $currency->getSymbol() . $space . $money->getAmount()
+            : $money->getAmount() . $space . $currency->getSymbol();
     }
 }

--- a/tests/Feature/ConvertCurrenciesTest.php
+++ b/tests/Feature/ConvertCurrenciesTest.php
@@ -2,28 +2,63 @@
 
 namespace PostScripton\Money\Tests;
 
+use Illuminate\Support\Facades\Config;
 use PostScripton\Money\Currency;
-use PostScripton\Money\Money;
+use PostScripton\Money\Exceptions\ServiceDoesNotSupportCurrencyException;
 
 class ConvertCurrenciesTest extends TestCase
 {
+	private $backup_config;
+
 	protected function setUp(): void
 	{
 		parent::setUp();
+		$this->backup_config = Config::get('money');
 		Currency::setCurrencyList(Currency::currentList());
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		Config::set('money', $this->backup_config);
 	}
 
 	/** @test */
     public function money_can_be_offline_converted_between_two_currencies_without_fails_in_number()
     {
-        $coeff = 75.32;
-        $rub = Money::make(10000, Currency::code('RUB'));
+        $rate = 75.32;
+        $rub = money(10000, currency('RUB'));
         $this->assertEquals('1 000 ₽', $rub->toString());
 
-        $usd = $rub->convertOfflineInto(Currency::code('USD'), 1 / $coeff);
-        $rub = $usd->convertOfflineInto(Currency::code('RUB'), $coeff / 1);
-
+        $usd = $rub->convertInto(currency('USD'), 1 / $rate);
         $this->assertEquals('$ 13.3', $usd->toString());
-        $this->assertEquals('1 000 ₽', $rub->toString());
+
+        $back_rub = $usd->convertInto(currency('RUB'), $rate / 1);
+        $this->assertEquals('1 000 ₽', $back_rub->toString());
+
+        $this->assertFalse($rub->equals($back_rub));
+        $this->assertTrue($rub->isSameCurrency($back_rub));
+        $this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+    }
+
+    /** @test */
+    public function the_given_currency_is_not_supported_for_converting_by_a_service()
+    {
+		Config::set('money.custom_currencies', [
+			[
+				'full_name' => 'QWERTY',
+				'name' => 'QWERTY',
+				'iso_code' => 'QWERTY',
+				'num_code' => '1234',
+				'symbol' => 'QWERTY',
+				'position' => Currency::POS_START,
+			]
+		]);
+		Currency::setCurrencyList(Currency::currentList());
+
+        $this->expectException(ServiceDoesNotSupportCurrencyException::class);
+
+        $money = money(1000);
+        $money->convertInto(currency('1234'));
     }
 }

--- a/tests/Feature/ConvertCurrenciesTest.php
+++ b/tests/Feature/ConvertCurrenciesTest.php
@@ -38,7 +38,7 @@ class ConvertCurrenciesTest extends TestCase
 
         $this->assertFalse($rub->equals($back_rub));
         $this->assertTrue($rub->isSameCurrency($back_rub));
-        $this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+        $this->assertEquals($rub->getPureAmount(), $back_rub->getPureAmount());
     }
 
     /** @test */

--- a/tests/Feature/DifferenceBetweenMoneyTest.php
+++ b/tests/Feature/DifferenceBetweenMoneyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace PostScripton\Money\Tests;
+
+use Illuminate\Support\Facades\Config;
+use PostScripton\Money\Currency;
+use PostScripton\Money\Exceptions\MoneyHasDifferentCurrenciesException;
+
+class DifferenceBetweenMoneyTest extends TestCase
+{
+	private $backup_config;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->backup_config = Config::get('money');
+		Currency::setCurrencyList(Currency::currentList());
+		Config::set('money.service', 'exchangerate');
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		Config::set('money', $this->backup_config);
+	}
+
+	/** @test */
+	public function difference_returns_a_string()
+	{
+		$m1 = money(500);
+		$m2 = money(1000);
+
+		$this->assertIsString($m1->difference($m2));
+	}
+	
+	/** @test */
+	public function difference_with_two_same_currencies()
+	{
+	    $m1 = money(500);
+	    $m2 = money(1000);
+
+	    $this->assertEquals(money(500)->subtract($m2)->toString(), $m1->difference($m2));
+	}
+
+	/** @test */
+	public function difference_with_two_different_currencies()
+	{
+		$usd = money(500);
+		$rub = money(1000, currency('rub'));
+		$rub_into_usd = $rub->convertInto($usd->getCurrency());
+
+		$this->assertEquals(money(500)->subtract($rub_into_usd)->toString(), $usd->difference($rub_into_usd));
+	}
+
+	/** @test */
+	public function an_exception_is_thrown_when_there_are_two_different_currencies()
+	{
+		$m1 = money(500);
+		$m2 = money(1000, currency('rub'));
+
+		$this->expectException(MoneyHasDifferentCurrenciesException::class);
+
+		$m1->difference($m2);
+	}
+
+	/** @test */
+	public function new_settings_can_be_applied_to_the_difference()
+	{
+		$m1 = money(500);
+		$m2 = money(1000);
+
+		$this->assertEquals(
+			money(500)->subtract($m2)->toString() . '.0',
+			$m1->difference($m2, settings()->setEndsWith0(true))
+		);
+	}
+}

--- a/tests/Feature/HelpersTest.php
+++ b/tests/Feature/HelpersTest.php
@@ -13,7 +13,7 @@ class HelpersTest extends TestCase
         $money = money(12345);
 
         $this->assertInstanceOf(Money::class, $money);
-        $this->assertEquals(12345, $money->getPureNumber());
+        $this->assertEquals(12345, $money->getPureAmount());
     }
 
     /** @test */

--- a/tests/Feature/ManipulatingMoneyNumberTest.php
+++ b/tests/Feature/ManipulatingMoneyNumberTest.php
@@ -176,7 +176,7 @@ class ManipulatingMoneyNumberTest extends TestCase
         $money = new Money(500, $settings);
 
         $this->assertEquals('$ -50', $money->subtract(1000)->toString());
-        $this->assertEquals(-500, $money->getPureNumber());
+        $this->assertEquals(-500, $money->getPureAmount());
     }
 
     /** @test */
@@ -187,7 +187,7 @@ class ManipulatingMoneyNumberTest extends TestCase
         $money = new Money(500, $settings);
 
         $this->assertEquals('$ -50', $money->subtract(100, MoneySettings::ORIGIN_FLOAT));
-        $this->assertEquals(-500, $money->getPureNumber());
+        $this->assertEquals(-500, $money->getPureAmount());
     }
 
     /** @test */
@@ -198,7 +198,7 @@ class ManipulatingMoneyNumberTest extends TestCase
         $money = new Money(50, $settings);
 
         $this->assertEquals('$ -50', $money->subtract(100, MoneySettings::ORIGIN_FLOAT));
-        $this->assertEquals(-50, $money->getPureNumber());
+        $this->assertEquals(-50, $money->getPureAmount());
     }
 
     /** @test */
@@ -209,7 +209,7 @@ class ManipulatingMoneyNumberTest extends TestCase
         $money = new Money(50, $settings);
 
         $this->assertEquals('$ -50', $money->subtract(1000));
-        $this->assertEquals(-50, $money->getPureNumber());
+        $this->assertEquals(-50, $money->getPureAmount());
     }
 
     /** @test */
@@ -269,7 +269,7 @@ class ManipulatingMoneyNumberTest extends TestCase
         $money = new Money(500);
         $money->multiple(1.5);
 
-        $this->assertEquals(750, $money->getPureNumber());
+        $this->assertEquals(750, $money->getPureAmount());
         $this->assertEquals('$ 75', $money->toString());
     }
 
@@ -279,7 +279,7 @@ class ManipulatingMoneyNumberTest extends TestCase
         $money = new Money(1000);
         $money->divide(2);
 
-        $this->assertEquals(500, $money->getPureNumber());
+        $this->assertEquals(500, $money->getPureAmount());
         $this->assertEquals('$ 50', $money->toString());
     }
 }

--- a/tests/Feature/MoneyFilteringTest.php
+++ b/tests/Feature/MoneyFilteringTest.php
@@ -77,7 +77,7 @@ class MoneyFilteringTest extends TestCase
 
         $avg = Money::avg($m1, $m2, $m3);
 
-        $this->assertEquals(2000, $avg->getPureNumber());
+        $this->assertEquals(2000, $avg->getPureAmount());
     }
 
     /** @test */
@@ -107,7 +107,7 @@ class MoneyFilteringTest extends TestCase
 
         $avg = Money::sum($m1, $m2, $m3);
 
-        $this->assertEquals(6000, $avg->getPureNumber());
+        $this->assertEquals(6000, $avg->getPureAmount());
     }
 
     /** @test */

--- a/tests/Feature/MoneyParseTest.php
+++ b/tests/Feature/MoneyParseTest.php
@@ -15,41 +15,41 @@ class MoneyParseTest extends TestCase
         $money = Money::parse('$ 1 234.5');
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals('$', $money->getCurrency()->getSymbol());
-        $this->assertEquals('1 234.5', $money->getNumber());
+        $this->assertEquals('1 234.5', $money->getAmount());
 
         $money = Money::parse('$ 123.4');
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals('$', $money->getCurrency()->getSymbol());
-        $this->assertEquals('123.4', $money->getNumber());
+        $this->assertEquals('123.4', $money->getAmount());
 
         $money = Money::parse('USD 123.4');
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals('$', $money->getCurrency()->getSymbol());
-        $this->assertEquals('123.4', $money->getNumber());
+        $this->assertEquals('123.4', $money->getAmount());
 
         $money = Money::parse('1 234.5 $');
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals('$', $money->getCurrency()->getSymbol());
-        $this->assertEquals('1 234.5', $money->getNumber());
+        $this->assertEquals('1 234.5', $money->getAmount());
 
         $money = Money::parse('1 234.5 USD');
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals('$', $money->getCurrency()->getSymbol());
-        $this->assertEquals('1 234.5', $money->getNumber());
+        $this->assertEquals('1 234.5', $money->getAmount());
 
         $money = Money::parse('$ -1 234.5');
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals('$', $money->getCurrency()->getSymbol());
-        $this->assertEquals('-1 234.5', $money->getNumber());
+        $this->assertEquals('-1 234.5', $money->getAmount());
 
         $money = Money::parse('USD -1 234.5');
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals('$', $money->getCurrency()->getSymbol());
-        $this->assertEquals('-1 234.5', $money->getNumber());
+        $this->assertEquals('-1 234.5', $money->getAmount());
 
         $money = Money::parse('$ 1 234.567890');
         $this->assertInstanceOf(Money::class, $money);
-        $this->assertEquals('1 234.6', $money->getNumber());
+        $this->assertEquals('1 234.6', $money->getAmount());
     }
     
     /** @test */
@@ -74,7 +74,7 @@ class MoneyParseTest extends TestCase
         $money = Money::parse("$ 1'234.5", null, '\'');
 
         $this->assertInstanceOf(Money::class, $money);
-        $this->assertEquals('1 234.5', $money->getNumber());
+        $this->assertEquals('1 234.5', $money->getAmount());
     }
 
     /** @test */
@@ -83,7 +83,7 @@ class MoneyParseTest extends TestCase
         $money = Money::parse("$ 1 234,5", null, null, ',');
 
         $this->assertInstanceOf(Money::class, $money);
-        $this->assertEquals('1 234.5', $money->getNumber());
+        $this->assertEquals('1 234.5', $money->getAmount());
     }
 
     /** @test */
@@ -92,7 +92,7 @@ class MoneyParseTest extends TestCase
         $money = Money::parse("1.234,5 ₽", Currency::code('RUB'), '.', ',');
 
         $this->assertInstanceOf(Money::class, $money);
-        $this->assertEquals('1 234.5', $money->getNumber());
+        $this->assertEquals('1 234.5', $money->getAmount());
         $this->assertEquals('₽', $money->getCurrency()->getSymbol());
         $this->assertEquals('RUB', $money->getCurrency()->getCode());
         $this->assertEquals(' ', $money->settings()->getThousandsSeparator());

--- a/tests/Feature/Services/CurrencyLayerTest.php
+++ b/tests/Feature/Services/CurrencyLayerTest.php
@@ -2,6 +2,7 @@
 
 namespace PostScripton\Money\Tests;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use PostScripton\Money\Currency;
 use PostScripton\Money\Exceptions\ServiceClassDoesNotExistException;
@@ -109,5 +110,15 @@ class CurrencyLayerTest extends TestCase
 //		$this->assertEquals('1 000 ₽', $back_rub->toString());
 //		$this->assertTrue($rub->isSameCurrency($back_rub));
 //		$this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+//	}
+//
+//	/** @test */
+//	public function exchangeratesapi_historical_converting()
+//	{
+//		$rub = money(10000, currency('rub'));
+//		$usd_now = $rub->convertInto(currency('usd'));
+//		$usd_historical = $rub->convertInto(currency('usd'), null, Carbon::createFromDate(2010, 9, 8));
+//
+//		$this->assertNotEquals($usd_now->getPureNumber(), $usd_historical->getPureNumber());
 //	}
 }

--- a/tests/Feature/Services/CurrencyLayerTest.php
+++ b/tests/Feature/Services/CurrencyLayerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace PostScripton\Money\Tests;
+
+use Illuminate\Support\Facades\Config;
+use PostScripton\Money\Currency;
+use PostScripton\Money\Exceptions\ServiceClassDoesNotExistException;
+use PostScripton\Money\Exceptions\ServiceDoesNotHaveClassException;
+use PostScripton\Money\Exceptions\ServiceDoesNotInheritServiceException;
+use PostScripton\Money\Exceptions\ServiceRequestFailedException;
+use PostScripton\Money\Services\CurrencyLayerService;
+use stdClass;
+
+class CurrencyLayerTest extends TestCase
+{
+	private $backup_config;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->backup_config = Config::get('money');
+		Currency::setCurrencyList(Currency::currentList());
+		Config::set('money.service', 'currencylayer');
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		Config::set('money', $this->backup_config);
+	}
+
+	/** @test */
+	public function getting_info_about_a_currencylayer_service()
+	{
+		$money = money(1000);
+
+		$this->assertInstanceOf(CurrencyLayerService::class, $money->service());
+		$this->assertEquals(CurrencyLayerService::class, $money->service()->getClassName());
+	}
+
+	/** @test */
+	public function an_incorrect_api_was_given_to_a_currencylayer_service()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['key' => 'incorrect_api_key'])
+		);
+
+		$this->expectException(ServiceRequestFailedException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function a_currencylayer_service_does_not_have_class()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_diff_key(config('money.services.' . config('money.service')), ['class' => ''])
+		);
+
+		$this->expectException(ServiceDoesNotHaveClassException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function a_currencylayer_service_class_does_not_exist()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['class' => 'incorrect_class'])
+		);
+
+		$this->expectException(ServiceClassDoesNotExistException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function a_currencylayer_service_class_does_not_inherit_the_main_one()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['class' => stdClass::class])
+		);
+
+		$this->expectException(ServiceDoesNotInheritServiceException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+//	/** @test */
+//	public function currencylayer_convert_currency()
+//	{
+//	    $rub = money(10000, currency('rub'));
+//	    $usd = $rub->convertInto(currency('usd'));
+//	}
+//
+//	/** @test */
+//	public function currencylayer_converting_back_and_forth_must_have_no_fails_in_number()
+//	{
+//		$rub = money(10000, currency('rub'));
+//		$usd = $rub->convertInto(currency('usd'));
+//
+//		$back_rub = $usd->convertInto(currency('rub'));
+//
+//		$this->assertFalse($rub->equals($back_rub));
+//		$this->assertEquals('1 000 ₽', $back_rub->toString());
+//		$this->assertTrue($rub->isSameCurrency($back_rub));
+//		$this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+//	}
+}

--- a/tests/Feature/Services/ExchangeRateTest.php
+++ b/tests/Feature/Services/ExchangeRateTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace PostScripton\Money\Tests;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Config;
+use PostScripton\Money\Currency;
+use PostScripton\Money\Exceptions\ServiceClassDoesNotExistException;
+use PostScripton\Money\Exceptions\ServiceDoesNotHaveClassException;
+use PostScripton\Money\Exceptions\ServiceDoesNotInheritServiceException;
+use PostScripton\Money\Services\ExchangeRateService;
+use stdClass;
+
+class ExchangeRateTest extends TestCase
+{
+	private $backup_config;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->backup_config = Config::get('money');
+		Currency::setCurrencyList(Currency::currentList());
+		Config::set('money.service', 'exchangerate');
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		Config::set('money', $this->backup_config);
+	}
+
+	/** @test */
+	public function getting_info_about_an_exchangerate_service()
+	{
+		$money = money(1000);
+
+		$this->assertInstanceOf(ExchangeRateService::class, $money->service());
+		$this->assertEquals(ExchangeRateService::class, $money->service()->getClassName());
+	}
+
+	/** @test */
+	public function an_exchangerate_service_does_not_have_class()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_diff_key(config('money.services.' . config('money.service')), ['class' => ''])
+		);
+
+		$this->expectException(ServiceDoesNotHaveClassException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function an_exchangerate_service_class_does_not_exist()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['class' => 'incorrect_class'])
+		);
+
+		$this->expectException(ServiceClassDoesNotExistException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function an_exchangerate_service_class_does_not_inherit_the_main_one()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['class' => stdClass::class])
+		);
+
+		$this->expectException(ServiceDoesNotInheritServiceException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function exchangerate_converting_back_and_forth_must_have_no_fails_in_number()
+	{
+		$rub = money(10000, currency('rub'));
+		$usd = $rub->convertInto(currency('usd'));
+
+		$back_rub = $usd->convertInto(currency('rub'));
+
+		$this->assertFalse($rub->equals($back_rub));
+		$this->assertEquals('1 000 ₽', $back_rub->toString());
+		$this->assertTrue($rub->isSameCurrency($back_rub));
+		$this->assertEquals($rub->toString(), $back_rub->toString());
+	}
+
+	/** @test */
+	public function exchangerate_historical_converting()
+	{
+		$rub = money(10000, currency('rub'));
+		$usd_now = $rub->convertInto(currency('usd'));
+		$usd_historical = $rub->convertInto(currency('usd'), null, Carbon::createFromDate(2010, 9, 8));
+
+		$this->assertNotEquals($usd_now->getPureNumber(), $usd_historical->getPureNumber());
+	}
+}

--- a/tests/Feature/Services/ExchangeRateTest.php
+++ b/tests/Feature/Services/ExchangeRateTest.php
@@ -98,6 +98,6 @@ class ExchangeRateTest extends TestCase
 		$usd_now = $rub->convertInto(currency('usd'));
 		$usd_historical = $rub->convertInto(currency('usd'), null, Carbon::createFromDate(2010, 9, 8));
 
-		$this->assertNotEquals($usd_now->getPureNumber(), $usd_historical->getPureNumber());
+		$this->assertNotEquals($usd_now->getPureAmount(), $usd_historical->getPureAmount());
 	}
 }

--- a/tests/Feature/Services/ExchangeRatesAPITest.php
+++ b/tests/Feature/Services/ExchangeRatesAPITest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace PostScripton\Money\Tests;
+
+use Illuminate\Support\Facades\Config;
+use PostScripton\Money\Currency;
+use PostScripton\Money\Exceptions\ServiceClassDoesNotExistException;
+use PostScripton\Money\Exceptions\ServiceDoesNotHaveClassException;
+use PostScripton\Money\Exceptions\ServiceDoesNotInheritServiceException;
+use PostScripton\Money\Exceptions\ServiceRequestFailedException;
+use PostScripton\Money\Services\ExchangeRatesAPIService;
+use stdClass;
+
+class ExchangeRatesAPITest extends TestCase
+{
+	private $backup_config;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->backup_config = Config::get('money');
+		Currency::setCurrencyList(Currency::currentList());
+		Config::set('money.service', 'exchangeratesapi');
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		Config::set('money', $this->backup_config);
+	}
+
+	/** @test */
+	public function getting_info_about_an_exchangeratesapi_service()
+	{
+		$money = money(1000);
+
+		$this->assertInstanceOf(ExchangeRatesAPIService::class, $money->service());
+		$this->assertEquals(ExchangeRatesAPIService::class, $money->service()->getClassName());
+	}
+
+	/** @test */
+	public function an_incorrect_api_was_given_to_an_exchangeratesapi_service()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['key' => 'incorrect_api_key'])
+		);
+
+		$this->expectException(ServiceRequestFailedException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function an_exchangeratesapi_service_does_not_have_class()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_diff_key(config('money.services.' . config('money.service')), ['class' => ''])
+		);
+
+		$this->expectException(ServiceDoesNotHaveClassException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function an_exchangeratesapi_service_class_does_not_exist()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['class' => 'incorrect_class'])
+		);
+
+		$this->expectException(ServiceClassDoesNotExistException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function an_exchangeratesapi_service_class_does_not_inherit_the_main_one()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['class' => stdClass::class])
+		);
+
+		$this->expectException(ServiceDoesNotInheritServiceException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function exchangeratesapi_converting_back_and_forth_must_have_no_fails_in_number()
+	{
+		$rub = money(10000, currency('rub'));
+		$usd = $rub->convertInto(currency('usd'));
+
+		$back_rub = $usd->convertInto(currency('rub'));
+
+		$this->assertFalse($rub->equals($back_rub));
+		$this->assertEquals('1 000 ₽', $back_rub->toString());
+		$this->assertTrue($rub->isSameCurrency($back_rub));
+		$this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+	}
+}

--- a/tests/Feature/Services/ExchangeRatesAPITest.php
+++ b/tests/Feature/Services/ExchangeRatesAPITest.php
@@ -102,7 +102,7 @@ class ExchangeRatesAPITest extends TestCase
 		$this->assertFalse($rub->equals($back_rub));
 		$this->assertEquals('1 000 ₽', $back_rub->toString());
 		$this->assertTrue($rub->isSameCurrency($back_rub));
-		$this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+		$this->assertEquals($rub->getPureAmount(), $back_rub->getPureAmount());
 	}
 
 	/** @test */
@@ -112,6 +112,6 @@ class ExchangeRatesAPITest extends TestCase
 		$usd_now = $rub->convertInto(currency('usd'));
 		$usd_historical = $rub->convertInto(currency('usd'), null, Carbon::createFromDate(2010, 9, 8));
 
-		$this->assertNotEquals($usd_now->getPureNumber(), $usd_historical->getPureNumber());
+		$this->assertNotEquals($usd_now->getPureAmount(), $usd_historical->getPureAmount());
 	}
 }

--- a/tests/Feature/Services/ExchangeRatesAPITest.php
+++ b/tests/Feature/Services/ExchangeRatesAPITest.php
@@ -2,6 +2,7 @@
 
 namespace PostScripton\Money\Tests;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use PostScripton\Money\Currency;
 use PostScripton\Money\Exceptions\ServiceClassDoesNotExistException;
@@ -102,5 +103,15 @@ class ExchangeRatesAPITest extends TestCase
 		$this->assertEquals('1 000 ₽', $back_rub->toString());
 		$this->assertTrue($rub->isSameCurrency($back_rub));
 		$this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+	}
+
+	/** @test */
+	public function exchangeratesapi_historical_converting()
+	{
+		$rub = money(10000, currency('rub'));
+		$usd_now = $rub->convertInto(currency('usd'));
+		$usd_historical = $rub->convertInto(currency('usd'), null, Carbon::createFromDate(2010, 9, 8));
+
+		$this->assertNotEquals($usd_now->getPureNumber(), $usd_historical->getPureNumber());
 	}
 }

--- a/tests/Feature/Services/OpenExchangeRatesTest.php
+++ b/tests/Feature/Services/OpenExchangeRatesTest.php
@@ -2,6 +2,7 @@
 
 namespace PostScripton\Money\Tests;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use PostScripton\Money\Currency;
 use PostScripton\Money\Exceptions\ServiceClassDoesNotExistException;
@@ -102,5 +103,15 @@ class OpenExchangeRatesTest extends TestCase
 		$this->assertEquals('1 000 ₽', $back_rub->toString());
 		$this->assertTrue($rub->isSameCurrency($back_rub));
 		$this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+	}
+
+	/** @test */
+	public function exchangeratesapi_historical_converting()
+	{
+		$rub = money(10000, currency('rub'));
+		$usd_now = $rub->convertInto(currency('usd'));
+		$usd_historical = $rub->convertInto(currency('usd'), null, Carbon::createFromDate(2010, 9, 8));
+
+		$this->assertNotEquals($usd_now->getPureNumber(), $usd_historical->getPureNumber());
 	}
 }

--- a/tests/Feature/Services/OpenExchangeRatesTest.php
+++ b/tests/Feature/Services/OpenExchangeRatesTest.php
@@ -102,7 +102,7 @@ class OpenExchangeRatesTest extends TestCase
 		$this->assertFalse($rub->equals($back_rub));
 		$this->assertEquals('1 000 ₽', $back_rub->toString());
 		$this->assertTrue($rub->isSameCurrency($back_rub));
-		$this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+		$this->assertEquals($rub->getPureAmount(), $back_rub->getPureAmount());
 	}
 
 	/** @test */
@@ -112,6 +112,6 @@ class OpenExchangeRatesTest extends TestCase
 		$usd_now = $rub->convertInto(currency('usd'));
 		$usd_historical = $rub->convertInto(currency('usd'), null, Carbon::createFromDate(2010, 9, 8));
 
-		$this->assertNotEquals($usd_now->getPureNumber(), $usd_historical->getPureNumber());
+		$this->assertNotEquals($usd_now->getPureAmount(), $usd_historical->getPureAmount());
 	}
 }

--- a/tests/Feature/Services/OpenExchangeRatesTest.php
+++ b/tests/Feature/Services/OpenExchangeRatesTest.php
@@ -31,7 +31,7 @@ class OpenExchangeRatesTest extends TestCase
 	}
 
 	/** @test */
-	public function getting_info_about_an_exchangeratesapi_service()
+	public function getting_info_about_an_openexchangerates_service()
 	{
 		$money = money(1000);
 
@@ -40,7 +40,7 @@ class OpenExchangeRatesTest extends TestCase
 	}
 
 	/** @test */
-	public function an_incorrect_api_was_given_to_an_exchangeratesapi_service()
+	public function an_incorrect_api_was_given_to_an_openexchangerates_service()
 	{
 		Config::set('money.services.' . config('money.service'),
 			array_merge(config('money.services.' . config('money.service')), ['key' => 'incorrect_api_key'])
@@ -53,7 +53,7 @@ class OpenExchangeRatesTest extends TestCase
 	}
 
 	/** @test */
-	public function an_exchangeratesapi_service_does_not_have_class()
+	public function an_openexchangerates_service_does_not_have_class()
 	{
 		Config::set('money.services.' . config('money.service'),
 			array_diff_key(config('money.services.' . config('money.service')), ['class' => ''])
@@ -66,7 +66,7 @@ class OpenExchangeRatesTest extends TestCase
 	}
 
 	/** @test */
-	public function an_exchangeratesapi_service_class_does_not_exist()
+	public function an_openexchangerates_service_class_does_not_exist()
 	{
 		Config::set('money.services.' . config('money.service'),
 			array_merge(config('money.services.' . config('money.service')), ['class' => 'incorrect_class'])
@@ -79,7 +79,7 @@ class OpenExchangeRatesTest extends TestCase
 	}
 
 	/** @test */
-	public function an_exchangeratesapi_service_class_does_not_inherit_the_main_one()
+	public function an_openexchangerates_service_class_does_not_inherit_the_main_one()
 	{
 		Config::set('money.services.' . config('money.service'),
 			array_merge(config('money.services.' . config('money.service')), ['class' => stdClass::class])
@@ -92,7 +92,7 @@ class OpenExchangeRatesTest extends TestCase
 	}
 
 	/** @test */
-	public function exchangeratesapi_converting_back_and_forth_must_have_no_fails_in_number()
+	public function openexchangerates_converting_back_and_forth_must_have_no_fails_in_number()
 	{
 		$rub = money(10000, currency('rub'));
 		$usd = $rub->convertInto(currency('usd'));
@@ -106,7 +106,7 @@ class OpenExchangeRatesTest extends TestCase
 	}
 
 	/** @test */
-	public function exchangeratesapi_historical_converting()
+	public function openexchangerates_historical_converting()
 	{
 		$rub = money(10000, currency('rub'));
 		$usd_now = $rub->convertInto(currency('usd'));

--- a/tests/Feature/Services/OpenExchangeRatesTest.php
+++ b/tests/Feature/Services/OpenExchangeRatesTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace PostScripton\Money\Tests;
+
+use Illuminate\Support\Facades\Config;
+use PostScripton\Money\Currency;
+use PostScripton\Money\Exceptions\ServiceClassDoesNotExistException;
+use PostScripton\Money\Exceptions\ServiceDoesNotHaveClassException;
+use PostScripton\Money\Exceptions\ServiceDoesNotInheritServiceException;
+use PostScripton\Money\Exceptions\ServiceRequestFailedException;
+use PostScripton\Money\Services\OpenExchangeRatesService;
+use stdClass;
+
+class OpenExchangeRatesTest extends TestCase
+{
+	private $backup_config;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->backup_config = Config::get('money');
+		Currency::setCurrencyList(Currency::currentList());
+		Config::set('money.service', 'openexchangerates');
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		Config::set('money', $this->backup_config);
+	}
+
+	/** @test */
+	public function getting_info_about_an_exchangeratesapi_service()
+	{
+		$money = money(1000);
+
+		$this->assertInstanceOf(OpenExchangeRatesService::class, $money->service());
+		$this->assertEquals(OpenExchangeRatesService::class, $money->service()->getClassName());
+	}
+
+	/** @test */
+	public function an_incorrect_api_was_given_to_an_exchangeratesapi_service()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['key' => 'incorrect_api_key'])
+		);
+
+		$this->expectException(ServiceRequestFailedException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function an_exchangeratesapi_service_does_not_have_class()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_diff_key(config('money.services.' . config('money.service')), ['class' => ''])
+		);
+
+		$this->expectException(ServiceDoesNotHaveClassException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function an_exchangeratesapi_service_class_does_not_exist()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['class' => 'incorrect_class'])
+		);
+
+		$this->expectException(ServiceClassDoesNotExistException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function an_exchangeratesapi_service_class_does_not_inherit_the_main_one()
+	{
+		Config::set('money.services.' . config('money.service'),
+			array_merge(config('money.services.' . config('money.service')), ['class' => stdClass::class])
+		);
+
+		$this->expectException(ServiceDoesNotInheritServiceException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+
+	/** @test */
+	public function exchangeratesapi_converting_back_and_forth_must_have_no_fails_in_number()
+	{
+		$rub = money(10000, currency('rub'));
+		$usd = $rub->convertInto(currency('usd'));
+
+		$back_rub = $usd->convertInto(currency('rub'));
+
+		$this->assertFalse($rub->equals($back_rub));
+		$this->assertEquals('1 000 ₽', $back_rub->toString());
+		$this->assertTrue($rub->isSameCurrency($back_rub));
+		$this->assertEquals($rub->getPureNumber(), $back_rub->getPureNumber());
+	}
+}

--- a/tests/Feature/Services/ServicesTest.php
+++ b/tests/Feature/Services/ServicesTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PostScripton\Money\Tests;
+
+use Illuminate\Support\Facades\Config;
+use PostScripton\Money\Currency;
+use PostScripton\Money\Exceptions\ServiceDoesNotExistException;
+use PostScripton\Money\Services\CurrencyLayerService;
+use PostScripton\Money\Services\ExchangeRatesAPIService;
+
+class ServicesTest extends TestCase
+{
+	private $backup_config;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->backup_config = Config::get('money');
+		Currency::setCurrencyList(Currency::currentList());
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		Config::set('money', $this->backup_config);
+	}
+
+	/** @test */
+	public function a_service_changes_depending_on_the_config_value_when_it_calls()
+	{
+		$money = money(1000);
+
+		Config::set('money.service', 'currencylayer');
+		$this->assertInstanceOf(CurrencyLayerService::class, $money->service());
+
+		Config::set('money.service', 'exchangeratesapi');
+		$this->assertInstanceOf(ExchangeRatesAPIService::class, $money->service());
+	}
+
+	/** @test */
+	public function a_service_does_not_exist()
+	{
+		Config::set('money.service', 'qwerty');
+
+		$this->expectException(ServiceDoesNotExistException::class);
+
+		$money = money(1000);
+		$money->convertInto(currency('rub'));
+	}
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,20 @@
 
 namespace PostScripton\Money\Tests;
 
+use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 use PostScripton\Money\MoneyServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
+	protected function getEnvironmentSetUp($app)
+	{
+		// https://github.com/orchestral/testbench/issues/211#issuecomment-360885812
+
+		$app->useEnvironmentPath(__DIR__.'/..');
+		$app->bootstrapWith([LoadEnvironmentVariables::class]);
+		parent::getEnvironmentSetUp($app);
+	}
+
 	protected function getPackageProviders($app): array
 	{
 		return [

--- a/tests/Unit/MoneyTest.php
+++ b/tests/Unit/MoneyTest.php
@@ -42,8 +42,8 @@ class MoneyTest extends TestCase
     {
         $money = Money::make(12345);
 
-        $this->assertEquals('1 234.5', $money->getNumber());
-        $this->assertEquals(12345.0, $money->getPureNumber());
+        $this->assertEquals('1 234.5', $money->getAmount());
+        $this->assertEquals(12345.0, $money->getPureAmount());
     }
 
 	/** @test */
@@ -62,12 +62,12 @@ class MoneyTest extends TestCase
 	{
 	    $money = new Money(132.76);
 
-	    $this->assertEquals(132.76, $money->getPureNumber());
+	    $this->assertEquals(132.76, $money->getPureAmount());
 	    $this->assertEquals('$ 13.3', $money->toString());
 
 	    $money->clear();
 
-	    $this->assertEquals(130, $money->getPureNumber());
+	    $this->assertEquals(130, $money->getPureAmount());
 	    $this->assertEquals('$ 13', $money->toString());
 	}
 
@@ -77,12 +77,12 @@ class MoneyTest extends TestCase
 	    $settings = new MoneySettings();
         $money = new Money(13.276, $settings->setOrigin(MoneySettings::ORIGIN_FLOAT));
 
-        $this->assertEquals(13.276, $money->getPureNumber());
+        $this->assertEquals(13.276, $money->getPureAmount());
         $this->assertEquals('$ 13.3', $money->toString());
 
         $money->clear();
 
-        $this->assertEquals(13, $money->getPureNumber());
+        $this->assertEquals(13, $money->getPureAmount());
         $this->assertEquals('$ 13', $money->toString());
 	}
 	
@@ -110,8 +110,8 @@ class MoneyTest extends TestCase
 
         $johnReward = $johnReward->add($winCoupon);
 
-        $this->assertEquals(1000, $bobReward->getPureNumber());
-        $this->assertEquals(1500, $johnReward->getPureNumber());
+        $this->assertEquals(1000, $bobReward->getPureAmount());
+        $this->assertEquals(1500, $johnReward->getPureAmount());
         $this->assertNotTrue($johnReward->equals($bobReward));
         $this->assertNotTrue($johnReward->settings() === $bobReward->settings());
 	}

--- a/tests/Unit/NegativeMoneyTest.php
+++ b/tests/Unit/NegativeMoneyTest.php
@@ -13,7 +13,7 @@ class NegativeMoneyTest extends TestCase
         $usd = new Money(-1234, Currency::code('USD'));
 
         $this->assertEquals('$ -123.4', $usd->toString());
-        $this->assertEquals(-1234, $usd->getPureNumber());
+        $this->assertEquals(-1234, $usd->getPureAmount());
         $this->assertTrue($usd->isNegative());
         $this->assertNotTrue($usd->isPositive());
     }
@@ -26,7 +26,7 @@ class NegativeMoneyTest extends TestCase
         $usd->settings()->setHasSpaceBetween(false); // for symbol at front this is true anyway
 
         $this->assertEquals('$ -123.4', $usd->toString());
-        $this->assertEquals(-1234, $usd->getPureNumber());
+        $this->assertEquals(-1234, $usd->getPureAmount());
         $this->assertTrue($usd->isNegative());
         $this->assertNotTrue($usd->isPositive());
     }
@@ -37,7 +37,7 @@ class NegativeMoneyTest extends TestCase
         $usd = new Money(-1234, Currency::code('USD')->setDisplay(Currency::DISPLAY_CODE));
 
         $this->assertEquals('USD -123.4', $usd->toString());
-        $this->assertEquals(-1234, $usd->getPureNumber());
+        $this->assertEquals(-1234, $usd->getPureAmount());
         $this->assertTrue($usd->isNegative());
         $this->assertNotTrue($usd->isPositive());
     }
@@ -50,7 +50,7 @@ class NegativeMoneyTest extends TestCase
         $usd->settings()->setHasSpaceBetween(false); // for DISPLAY_CODE this is true anyway
 
         $this->assertEquals('USD -123.4', $usd->toString());
-        $this->assertEquals(-1234, $usd->getPureNumber());
+        $this->assertEquals(-1234, $usd->getPureAmount());
         $this->assertTrue($usd->isNegative());
         $this->assertNotTrue($usd->isPositive());
     }
@@ -61,7 +61,7 @@ class NegativeMoneyTest extends TestCase
         $usd = new Money(-1234, Currency::code('RUB'));
 
         $this->assertEquals('-123.4 ₽', $usd->toString());
-        $this->assertEquals(-1234, $usd->getPureNumber());
+        $this->assertEquals(-1234, $usd->getPureAmount());
         $this->assertTrue($usd->isNegative());
         $this->assertNotTrue($usd->isPositive());
     }
@@ -72,7 +72,7 @@ class NegativeMoneyTest extends TestCase
         $usd = new Money(-1234, Currency::code('RUB')->setDisplay(Currency::DISPLAY_CODE));
 
         $this->assertEquals('-123.4 RUB', $usd->toString());
-        $this->assertEquals(-1234, $usd->getPureNumber());
+        $this->assertEquals(-1234, $usd->getPureAmount());
         $this->assertTrue($usd->isNegative());
         $this->assertNotTrue($usd->isPositive());
     }

--- a/tests/Unit/OriginTest.php
+++ b/tests/Unit/OriginTest.php
@@ -15,8 +15,8 @@ class OriginTest extends TestCase
 
         $money = new Money(132.76686139139672, $settings);
 
-        $this->assertEquals('13.3', $money->getNumber());
-        $this->assertEquals(132.76686139139672, $money->getPureNumber());
+        $this->assertEquals('13.3', $money->getAmount());
+        $this->assertEquals(132.76686139139672, $money->getPureAmount());
         $this->assertEquals(132, $money->upload());
     }
 
@@ -28,8 +28,8 @@ class OriginTest extends TestCase
 
         $money = new Money(13.276686139139672, $settings);
 
-        $this->assertEquals('13.3', $money->getNumber());
-        $this->assertEquals(13.276686139139672, $money->getPureNumber());
+        $this->assertEquals('13.3', $money->getAmount());
+        $this->assertEquals(13.276686139139672, $money->getPureAmount());
         $this->assertEquals(13.2, $money->upload());
     }
 
@@ -40,12 +40,12 @@ class OriginTest extends TestCase
         $settings->setOrigin(MoneySettings::ORIGIN_INT);
 
         $money = new Money(132.76686139139672, $settings);
-        $this->assertEquals(132.76686139139672, $money->getPureNumber());
+        $this->assertEquals(132.76686139139672, $money->getPureAmount());
 
         $money->settings()->setOrigin(MoneySettings::ORIGIN_FLOAT);
 
-        $this->assertEquals('13.3', $money->getNumber());
-        $this->assertEquals(13.276686139139672, $money->getPureNumber());
+        $this->assertEquals('13.3', $money->getAmount());
+        $this->assertEquals(13.276686139139672, $money->getPureAmount());
         $this->assertEquals(13.2, $money->upload());
     }
 
@@ -56,12 +56,12 @@ class OriginTest extends TestCase
         $settings->setOrigin(MoneySettings::ORIGIN_FLOAT);
 
         $money = new Money(13.276686139139672, $settings);
-        $this->assertEquals(13.276686139139672, $money->getPureNumber());
+        $this->assertEquals(13.276686139139672, $money->getPureAmount());
 
         $money->settings()->setOrigin(MoneySettings::ORIGIN_INT);
 
-        $this->assertEquals('13.3', $money->getNumber());
-        $this->assertEquals(132.76686139139672, $money->getPureNumber());
+        $this->assertEquals('13.3', $money->getAmount());
+        $this->assertEquals(132.76686139139672, $money->getPureAmount());
         $this->assertEquals(132, $money->upload());
     }
 }

--- a/tests/Unit/UploadTest.php
+++ b/tests/Unit/UploadTest.php
@@ -13,7 +13,7 @@ class UploadTest extends TestCase
         $money = Money::make(12345.67890);
 
         $this->assertEquals(12345, $money->upload());
-        $this->assertEquals(12345.67890, $money->getPureNumber());
+        $this->assertEquals(12345.67890, $money->getPureAmount());
     }
 
     /** @test */
@@ -23,6 +23,6 @@ class UploadTest extends TestCase
         $money->settings()->setOrigin(MoneySettings::ORIGIN_FLOAT);
 
         $this->assertEquals(1234.5, $money->upload());
-        $this->assertEquals(1234.567890, $money->getPureNumber());
+        $this->assertEquals(1234.567890, $money->getPureAmount());
     }
 }


### PR DESCRIPTION
This update brings us online converting currencies 💵🌐

## Services for converting

This update offers you to use one of the four API services, so it’s up to you which to use.

In the config file, you can choose the service and even add your own service. Notice that some of them require an API key and some of them don’t.

### Adding your own service

In order to create your own service, you need to create a class that extends the `PostScripton\Money\Services\AbstractService` class.

All that your class consists of is overriding methods and properties. There are few of them:

```php
protected string $currencies = 'symbols';	// stands for naming of currencies list for passing to the query
protected string $base = 'base';			// stands for base currencies in the query
protected string $result = 'rates';			// stands for result property with all the rates
```

Methods:

```php
// runs with creating the service
public function boot(): void
{
    parent::boot();
    // your code here
}
```

```php
// the base query for creating a client
protected function baseQuery(): array
{
    return [
        'access_key' => $this->config['key']
    ];
}
```

```php
// a domain name
protected function domain(): string
{
    return 'example.com';
}
```

```php
// a uri after the domain name
protected function uri(): string
{
    return 'api/v1';
}
```

```php
// if there is a restriction to change a base currency, then what is this base currency?
protected static function BASE_CURRENCY(): string
{
    return 'USD';
}
```

```php
// a result may come in different formats
// for example, "USDRUB" or just "RUB"
// supported: FROM_TO_FORMAT and TO_FORMAT
protected function resultFormat(): int
{
    return self::TO_FORMAT;
}
```

```php
// a part of the url that leads to the supported currencies data
// example.com/api/v1/symbols
protected function supportedUri(): string
{
    return 'symbols';
}
```

```php
// a part of the url that leads to the latest rates data
// example.com/api/v1/latest
protected function latestUri(): string
{
    return 'latest';
}
```

```php
// a part of the url that leads to the historical rates data

// example.com/api/v1/2010-12-31
protected function historicalUri(Carbon $date, array &$query): string
{
    return $date->format(self::DATE_FORMAT);
}

// example.com/api/v1/historical?date=2010-12-31
protected function historicalUri(Carbon $date, array &$query): string
{
    // IT IS IMPORTANT TO MERGE THE QUERY!!!
    // In order not to lost you previous parameters such as api key, currencies and so on
    $query = array_merge($query, [
        'date' => $date->format(self::DATE_FORMAT)
    ]);

    return 'historical';
}
```

```php
// a way to get data from supported currencies if it is different
protected function supportedData(array $data, string $index): array
{
    return $data[$index];
}
```

```php
// a way to get data from latest rates if it is different
protected function latestData(array $data, string $index): float
{
    return $data[$this->result][$index];
}
```

```php
// validates if there are any errors
protected function validateResponse(array $data): void
{
    // Verify the server response
    if (array_key_exists('error', $data)) {
        throw new ServiceRequestFailedException($this->getClassName(), $data['error']['code'], $data['error']['info']);
    }
}
```

That’s all! All you need to do is to override some of these methods, not all of them!

However, you are free to even change `rate()` and `supports()` methods :smile:

## New method

Money object now has the `difference()` method. It returns a string of a difference between two money objects with the settings of the main one or with the given settings.

Both money objects must be **the same currencies**!

```php
$m1 = money(500);
$m2 = money(1000);

$m1->difference($m2); // "$ -50"
$m1->difference($m2, settings()->setEndsWith0(true)); // "$ -50.0"
```

Otherwise, the exception `MoneyHasDifferentCurrenciesException` will be thrown.

## Other changes

It was considered lately to rename methods `getNumber()` and `getPureNumber()` into something more meaningful. So it was decided to change `number` on `amount` and so we got `getAmount()` and `getPureAmount()`