### PR TITLE
Get current currencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ After all, the config file at `config/money.php` should be modified for your own
     - [Display](/docs/03_Currencies/display.md)
     - [Currency List](/docs/03_Currencies/currency_list.md)
     - [Preferred symbol](/docs/03_Currencies/preferred_symbol.md)
+    - [Get current currencies](/docs/03_Currencies/get_currencies.md)
 4. [💵 Money](/docs/04_Money/base.md)
     - Static methods
         - [Getters](/docs/04_Money/static/getters.md)

--- a/docs/03_Currencies/base.md
+++ b/docs/03_Currencies/base.md
@@ -30,6 +30,7 @@ You can also get or change some data from Currency object:
 3. [Display](/docs/03_Currencies/display.md)
 4. [Currency List](/docs/03_Currencies/currency_list.md)
 5. [Preferred symbol](/docs/03_Currencies/preferred_symbol.md)
+6. [Get current currencies](/docs/03_Currencies/get_currencies.md)
 
 ---
 

--- a/docs/03_Currencies/get_currencies.md
+++ b/docs/03_Currencies/get_currencies.md
@@ -1,0 +1,21 @@
+# Get current currencies
+
+Get all the chosen (current) currencies.
+
+## Methods
+
+### `Currency::getCurrencies`
+**Returns**: `array` as `["USD", "EUR", ...]`
+
+## Usage
+
+```php
+use PostScripton\Money\Currency;
+
+Currency::setCurrencyList(Currency::LIST_POPULAR);
+Currency::getCurrencies(); // ["USD", "EUR", ...]
+```
+
+---
+
+📌 Back to the [contents](/README.md#table-of-contents).

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -183,6 +183,13 @@ class Currency
         return $this;
     }
 
+    public static function getCurrencies(): array
+    {
+        return self::currencies()
+            ->map(fn(self $currency) => $currency->getCode())
+            ->toArray();
+    }
+
     public static function isIncorrectList(string $list): bool
     {
         return !in_array(

--- a/tests/Unit/CurrencyTest.php
+++ b/tests/Unit/CurrencyTest.php
@@ -10,6 +10,8 @@ use PostScripton\Money\Tests\TestCase;
 
 class CurrencyTest extends TestCase
 {
+    private string $list;
+
     /** @test */
     public function checkingCurrencyPropsByCodeTest()
     {
@@ -84,5 +86,31 @@ class CurrencyTest extends TestCase
         $this->assertEquals('$', $money->getCurrency()->getSymbol(1));
 
         Currency::setCurrencyList(Currency::LIST_CONFIG);
+    }
+
+    /** @test */
+    public function getAllTheCurrenciesAsArray()
+    {
+        Currency::setCurrencyList(Currency::LIST_POPULAR);
+        $actual = require __DIR__ . '/../../src/Lists/popular_currencies.php';
+        $allCurrencies = Currency::getCurrencies();
+
+        $this->assertCount(count($actual), $allCurrencies);
+        $this->assertEquals(
+            collect($actual)->map(fn(array $currency) => $currency['iso_code'])->toArray(),
+            $allCurrencies
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->list = Currency::currentList();
+    }
+
+    protected function tearDown(): void
+    {
+        Currency::setCurrencyList($this->list);
+        parent::tearDown();
     }
 }


### PR DESCRIPTION
This small update brings an ability to get an array of ISO codes of currently chosen currencies. For this purpose, we are introducing a new method called `Money::getCurrencies()`. (https://github.com/PostScripton/laravel-money/issues/18)

```php
use PostScription\Money \Money;

Currency::setCurrencyList(Currency::LIST_POPULAR);
Currency::getCurrencies(); // ["USD", "EUR", ...]
```