### PR TITLE
Rename methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ After all, the config file at `config/money.php` should be modified for your own
             - [`rebase()`](/docs/04_money/object/rebase.md)
         - Object manipulations
             - [`floor()`](/docs/04_money/object/floor.md)
+            - [`ceil()`](/docs/04_money/object/ceil.md)
             - [`clone()` (soon)](#)
         - Logical operations
             - [`isSameCurrency()`](/docs/04_money/object/isSameCurrency.md)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ After all, the config file at `config/money.php` should be modified for your own
             - [`divide()`](/docs/04_money/object/divide.md)
             - [`rebase()`](/docs/04_money/object/rebase.md)
         - Object manipulations
-            - [`clear()`](/docs/04_money/object/clear.md)
+            - [`floor()`](/docs/04_money/object/floor.md)
             - [`clone()` (soon)](#)
         - Logical operations
             - [`isSameCurrency()`](/docs/04_money/object/isSameCurrency.md)

--- a/docs/04_money/README.md
+++ b/docs/04_money/README.md
@@ -21,7 +21,7 @@ There are *static* methods as well as *object* ones.
         - [`divide()`](/docs/04_money/object/divide.md)
         - [`rebase()`](/docs/04_money/object/rebase.md)
     - Object manipulations
-        - [`clear()`](/docs/04_money/object/clear.md)
+        - [`floor()`](/docs/04_money/object/floor.md)
         - [`clone()` (soon)](#)
     - Logical operations
         - [`isSameCurrency()`](/docs/04_money/object/isSameCurrency.md)

--- a/docs/04_money/README.md
+++ b/docs/04_money/README.md
@@ -22,6 +22,7 @@ There are *static* methods as well as *object* ones.
         - [`rebase()`](/docs/04_money/object/rebase.md)
     - Object manipulations
         - [`floor()`](/docs/04_money/object/floor.md)
+        - [`ceil()`](/docs/04_money/object/ceil.md)
         - [`clone()` (soon)](#)
     - Logical operations
         - [`isSameCurrency()`](/docs/04_money/object/isSameCurrency.md)

--- a/docs/04_money/object/ceil.md
+++ b/docs/04_money/object/ceil.md
@@ -1,0 +1,19 @@
+# `ceil()`
+
+Round fractions up. `$10.25 -> $11.00`
+
+## Methods
+
+### `ceil()`
+**Returns**: `Money`
+
+## Usage
+
+```php
+$money = money(105);    // "$ 10.5"
+$money->ceil();         // "$ 11"
+```
+
+---
+
+📌 Back to the [contents](/docs/04_money/README.md).

--- a/docs/04_money/object/floor.md
+++ b/docs/04_money/object/floor.md
@@ -1,17 +1,17 @@
-# `clear()`
+# `floor()`
 
-removes decimals. `$10.25 -> $10.00`
+Round fractions down. `$10.25 -> $10.00`
 
 ## Methods
 
-### `clear()`
+### `floor()`
 **Returns**: `Money`
 
 ## Usage
 
 ```php
 $money = money(105);    // "$ 10.5"
-$money->clear();        // "$ 10"
+$money->floor();        // "$ 10"
 ```
 
 ---

--- a/src/Money.php
+++ b/src/Money.php
@@ -149,6 +149,15 @@ class Money implements MoneyInterface
         return $this;
     }
 
+    public function ceil(): self
+    {
+        $this->amount = $this->settings()->getOrigin() === MoneySettings::ORIGIN_INT
+            ? ceil($this->getPureAmount() / $this->getDivisor()) * $this->getDivisor()
+            : ceil($this->getPureAmount());
+
+        return $this;
+    }
+
     public function isSameCurrency(self $money): bool
     {
         return $this->settings()->getCurrency()->getCode() === $money->settings()->getCurrency()->getCode();

--- a/src/Money.php
+++ b/src/Money.php
@@ -140,7 +140,7 @@ class Money implements MoneyInterface
         return $this;
     }
 
-    public function clear(): self
+    public function floor(): self
     {
         $this->amount = $this->settings()->getOrigin() === MoneySettings::ORIGIN_INT
             ? floor($this->getPureAmount() / $this->getDivisor()) * $this->getDivisor()

--- a/src/PHPDocs/MoneyInterface.php
+++ b/src/PHPDocs/MoneyInterface.php
@@ -106,11 +106,11 @@ interface MoneyInterface
     public function rebase($money, int $origin = MoneySettings::ORIGIN_INT): Money;
 
     /**
-     * Removes decimals. It's like <p>
+     * Round fractions down <p>
      * `$10.25 -> $10.00` </p>
      * @return Money
      */
-    public function clear(): Money;
+    public function floor(): Money;
 
     /**
      * Checks whether two money objects have the same currency

--- a/src/PHPDocs/MoneyInterface.php
+++ b/src/PHPDocs/MoneyInterface.php
@@ -113,6 +113,13 @@ interface MoneyInterface
     public function floor(): Money;
 
     /**
+     * Round fractions up <p>
+     * `$10.25 -> $11.00` </p>
+     * @return Money
+     */
+    public function ceil(): Money;
+
+    /**
      * Checks whether two money objects have the same currency
      * @param Money $money
      * @return bool

--- a/tests/Unit/MoneyTest.php
+++ b/tests/Unit/MoneyTest.php
@@ -85,6 +85,35 @@ class MoneyTest extends TestCase
     }
 
     /** @test */
+    public function originIntMoneyGetsRidOfDecimalsWithCeilMethod()
+    {
+        $money = new Money(132.76);
+
+        $this->assertEquals(132.76, $money->getPureAmount());
+        $this->assertEquals('$ 13.3', $money->toString());
+
+        $money->ceil();
+
+        $this->assertEquals(140, $money->getPureAmount());
+        $this->assertEquals('$ 14', $money->toString());
+    }
+
+    /** @test */
+    public function originFloatMoneyGetsRidOfDecimalsWithCeilMethod()
+    {
+        $settings = new MoneySettings();
+        $money = new Money(13.276, $settings->setOrigin(MoneySettings::ORIGIN_FLOAT));
+
+        $this->assertEquals(13.276, $money->getPureAmount());
+        $this->assertEquals('$ 13.3', $money->toString());
+
+        $money->ceil();
+
+        $this->assertEquals(14, $money->getPureAmount());
+        $this->assertEquals('$ 14', $money->toString());
+    }
+
+    /** @test */
     public function anErrorThatMoneyObjectsAreImmutable()
     {
         $johnReward = $bobReward = new Money(1000);

--- a/tests/Unit/MoneyTest.php
+++ b/tests/Unit/MoneyTest.php
@@ -56,21 +56,21 @@ class MoneyTest extends TestCase
     }
 
     /** @test */
-    public function originIntMoneyGetsRidOfDecimalsWithClearMethod()
+    public function originIntMoneyGetsRidOfDecimalsWithFloorMethod()
     {
         $money = new Money(132.76);
 
         $this->assertEquals(132.76, $money->getPureAmount());
         $this->assertEquals('$ 13.3', $money->toString());
 
-        $money->clear();
+        $money->floor();
 
         $this->assertEquals(130, $money->getPureAmount());
         $this->assertEquals('$ 13', $money->toString());
     }
 
     /** @test */
-    public function originFloatMoneyGetsRidOfDecimalsWithClearMethod()
+    public function originFloatMoneyGetsRidOfDecimalsWithFloorMethod()
     {
         $settings = new MoneySettings();
         $money = new Money(13.276, $settings->setOrigin(MoneySettings::ORIGIN_FLOAT));
@@ -78,7 +78,7 @@ class MoneyTest extends TestCase
         $this->assertEquals(13.276, $money->getPureAmount());
         $this->assertEquals('$ 13.3', $money->toString());
 
-        $money->clear();
+        $money->floor();
 
         $this->assertEquals(13, $money->getPureAmount());
         $this->assertEquals('$ 13', $money->toString());


### PR DESCRIPTION
**Breaking change!**

1. Renamed method `clear()` to `floor()`.
2. Added new methods `ceil()` that does the opposite.