### PR TITLE
Cloning money objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ After all, the config file at `config/money.php` should be modified for your own
 1. ✅ Usage
     - [🧰 Creating](/docs/01_usage/creating.md)
     - [🖨️ Output](/docs/01_usage/output.md)
+    - [📄 Cloning](/docs/01_usage/cloning.md)
 2. [⚙ Settings](/docs/02_settings/README.md)
     - [Decimals](/docs/02_settings/decimals.md)
     - [Thousands separator](/docs/02_settings/thousands_separator.md)

--- a/docs/01_usage/cloning.md
+++ b/docs/01_usage/cloning.md
@@ -1,0 +1,9 @@
+# 📄 Cloning
+
+This is an essential part. Each and every method of an object returns itself.
+As everybody knows, all objects in PHP are referential, so they don't get copied when you return it within a method or assign it to a variable.
+
+Thus, if you want to assign object to another variable or something, you should clone it and work with an absolutely new instance that has identical configuration (amount, currency, settings).
+To accomplish that, we make up with a convenient method, which is called `clone()`. It simply returns a new instance of a money object.
+
+👀 See [here](/docs/04_money/object/clone.md) for full details.

--- a/docs/04_money/object/clone.md
+++ b/docs/04_money/object/clone.md
@@ -1,0 +1,44 @@
+# `clone()`
+
+creates an absolutely identical instance of the object.
+
+## Methods
+
+### `clone()`
+**Returns**: `Money` (new instance with the same settings)
+
+## Usage
+
+```php
+$bobReward = money(1000);
+
+$johnReward = $bobReward
+    // Add for both John and Bob because John refers to Bob's object
+    ->add(500)
+    // John's reward is 1500 as long as Bob's one but John's reward is independent now
+    ->clone()
+    // Multiplies John's reward by 2 without affecting Bob's reward at all
+    ->multiple(2);
+
+$bobReward->getPureAmount();    // 1500
+$johnReward->getPureAmount();   // 3000
+```
+
+The next example is wrong for this purpose:
+
+```php
+$bobReward = money(1000);
+
+$johnReward = $bobReward
+    // Add for both John and Bob because John refers to Bob's object
+    ->add(500)
+    // Multiplies both John and Bob because John refers to Bob's object
+    ->multiple(2);
+
+$bobReward->getPureAmount();    // 3000
+$johnReward->getPureAmount();   // 3000
+```
+
+---
+
+📌 Back to the [contents](/docs/04_money/README.md).

--- a/docs/04_money/object/convertInto.md
+++ b/docs/04_money/object/convertInto.md
@@ -2,7 +2,7 @@
 
 converts money into another currency using an exchange rate between currencies.
 
-See [here](/docs/05_services/README.md) for full details.
+👀 See [here](/docs/05_services/README.md) for full details.
 
 For example:
 ```text

--- a/docs/04_money/object/service.md
+++ b/docs/04_money/object/service.md
@@ -2,7 +2,7 @@
 
 allows you to get access to the selected service from the config file.
 
-See [here](/docs/05_services/README.md) for full details.
+👀 See [here](/docs/05_services/README.md) for full details.
 
 ## Methods
 

--- a/docs/05_services/README.md
+++ b/docs/05_services/README.md
@@ -18,7 +18,7 @@ You can choose whatever you like by changing it in the property `service` of the
 
 ## What if there is no service I want?
 
-In this case, you can add your own service, see [here](/docs/05_services/add.md) for full details.
+In this case, you can add your own service, 👀 see [here](/docs/05_services/add.md) for full details.
 
 ---
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -74,6 +74,11 @@ class Money implements MoneyInterface
         return $this->settings;
     }
 
+    public function clone(): self
+    {
+        return money($this->amount, $this->getCurrency(), clone $this->settings());
+    }
+
     public function getPureAmount(): float
     {
         return $this->amount;

--- a/src/PHPDocs/MoneyInterface.php
+++ b/src/PHPDocs/MoneyInterface.php
@@ -26,6 +26,12 @@ interface MoneyInterface
     public function settings(): MoneySettings;
 
     /**
+     * Creates an absolutely identical instance of the object
+     * @return Money
+     */
+    public function clone(): Money;
+
+    /**
      * Returns a formatted number <p>
      * For example, "$ 1 234.5" -> "1 234.5" </p>
      * @return string

--- a/tests/Unit/MoneyTest.php
+++ b/tests/Unit/MoneyTest.php
@@ -114,32 +114,20 @@ class MoneyTest extends TestCase
     }
 
     /** @test */
-    public function anErrorThatMoneyObjectsAreImmutable()
-    {
-        $johnReward = $bobReward = new Money(1000);
-
-        // John has additional bonus $50
-        $winCoupon = new Money(500);
-
-        $johnReward->add($winCoupon);
-
-        $this->assertTrue($johnReward->equals($bobReward));
-    }
-
-    /** @test */
     public function correctWayToHandleImmutableMoneyObjects()
     {
-        $johnReward = new Money(1000);
-        $bobReward = new Money(1000);
+        $m1 = money(1000);
 
-        // John has additional bonus $50
-        $winCoupon = new Money(500);
+        $m2 = $m1
+            // adds to the both
+            ->add(500)
+            // $m2 is 1500 as long as $m1 but $m2 is independent now
+            ->clone()
+            // $m2 is 3000 whereas $m1 is still 1500
+            ->multiple(2);
 
-        $johnReward = $johnReward->add($winCoupon);
-
-        $this->assertEquals(1000, $bobReward->getPureAmount());
-        $this->assertEquals(1500, $johnReward->getPureAmount());
-        $this->assertNotTrue($johnReward->equals($bobReward));
-        $this->assertNotTrue($johnReward->settings() === $bobReward->settings());
+        $this->assertEquals(1500, $m1->getPureAmount());
+        $this->assertEquals(3000, $m2->getPureAmount());
+        $this->assertFalse($m1->equals($m2));
     }
 }


### PR DESCRIPTION
This is an important part of the entire library because this update brings us a new method and functionality for cloning money objects.
So as everybody knows, all objects in PHP are referential, so they don't get copied when you return it within a method or assign it to a variable.
Thus a new method `clone()` allows you to get a copy of an existing object with all the same configuration (amount, currency, and settings), otherwise, you would get a reference to the first object, but not a new instance.